### PR TITLE
Add Gradle configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Something amiss or not quite right? Please post the full output of a run to an i
 - Python: sets the `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, and `CURL_CA_BUNDLE` environment variables.
 - gcloud: configures the `core/custom_ca_certs_file` for the Google Cloud `gcloud` CLI.
 - Java/JVM: adds the Cloudflare certificate to any found Java keystore (cacerts).
+ - Gradle: sets `systemProp` entries in `gradle.properties` (respecting `GRADLE_USER_HOME`) for the WARP certificate.
 - DBeaver: targets the bundled JRE and adds the certificate to its keystore.
 - wget: configures the `ca_certificate` in the `.wgetrc` file.
 - Podman: installs certificate in Podman VM's trust store.


### PR DESCRIPTION
## Summary
- detect Gradle installations and configure `gradle.properties` with WARP trust store and TLS settings
- verify Gradle settings in status mode
- document Gradle support in README

## Testing
- `python -m py_compile fuwarp.py`
- `./fuwarp.py --list-tools`
- `python - <<'PY'
import os, tempfile
from fuwarp import FuwarpPython
with tempfile.TemporaryDirectory() as d:
    os.environ['GRADLE_USER_HOME'] = d
    path = os.path.join(d, 'gradle.properties')
    with open(path, 'w') as f:
        f.write('systemProp.javax.net.ssl.trustStore=foo\n')
    fuw = FuwarpPython()
    with tempfile.NamedTemporaryFile() as tf:
        fuw.check_gradle_status(tf.name)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689a40b8da988330a3004ddf316014d2