### PR TITLE
Add jenv support for managing certificates across multiple Java installations

### DIFF
--- a/fuwarp.py
+++ b/fuwarp.py
@@ -175,6 +175,13 @@ class FuwarpPython:
                 'check_func': self.check_java_status,
                 'description': 'Java runtime and development kit'
             },
+            'jenv': {
+                'name': 'jenv (Java Environment Manager)',
+                'tags': ['jenv', 'java', 'jvm', 'jdk'],
+                'setup_func': self.setup_jenv_cert,
+                'check_func': self.check_jenv_status,
+                'description': 'jenv-managed Java installations'
+            },
             'dbeaver': {
                 'name': 'DBeaver',
                 'tags': ['dbeaver', 'database', 'db'],


### PR DESCRIPTION
## Summary

Adds support for jenv (Java Environment Manager) to automatically install the Cloudflare WARP CA certificate to all Java installations managed by jenv.

## Motivation

Users with multiple Java versions managed by jenv need to install the WARP certificate to each JDK separately. This PR automates that process by discovering all unique Java installations and installing/checking certificates for each one.

## Changes

### New Functions

1. **`get_jenv_java_homes()`** - Helper function
   - Runs `jenv versions --verbose` to discover Java installations
   - Parses output to extract physical JDK paths (after `-->` markers)
   - Deduplicates symlink aliases to get unique installations
   - Skips "system" entry that points to user home directory

2. **`setup_jenv_cert()`** - Certificate installation
   - Discovers all jenv-managed Java installations
   - For each JDK:
     - Locates `lib/security/cacerts` file
     - Checks if certificate already exists
     - Installs certificate using keytool if missing
   - Provides per-JDK status reporting with version names
   - Handles permissions appropriately

3. **`check_jenv_status()`** - Status checking
   - Checks each jenv-managed JDK for certificate presence
   - Reports status per JDK version
   - Returns `has_issues` boolean for overall status

### Integration

- Added `jenv` to the main tool registry
- Enabled `--tools jenv` flag support
- Integrated into standard setup and check workflows

## Usage

```bash
# Check status of all jenv-managed Java installations
./fuwarp.py

# Install certificates to all jenv-managed Java installations
./fuwarp.py --fix

# Only check/fix jenv installations
./fuwarp.py --tools jenv
./fuwarp.py --fix --tools jenv
```

## Example Output

```
Found 3 jenv-managed Java installation(s)
  ✓ temurin-17: Certificate already installed
  Installing certificate for temurin-11...
    ✓ temurin-11: Certificate added successfully
  Installing certificate for temurin-8...
    ✓ temurin-8: Certificate added successfully
```

## Testing

Tested on macOS with jenv managing 3 Java installations (temurin-8, temurin-11, temurin-17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)