### PR TITLE
Add Windows CI testing with GitHub Actions

### DIFF
--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -46,22 +46,31 @@ jobs:
     - name: Test script imports and basic functionality
       shell: pwsh
       run: |
-        python -c "import sys; sys.path.insert(0, '.'); from fuwarp_windows import FuwarpWindows; print('Import successful')"
+        # Set UTF-8 encoding for Python to handle Unicode characters
+        $env:PYTHONIOENCODING = "utf-8"
+
+        # Test direct script execution (not as a module import)
         python fuwarp-windows.py --help
         python fuwarp-windows.py --version
 
     - name: Test in status mode (read-only)
       shell: pwsh
-      run: python fuwarp-windows.py
+      run: |
+        # Set UTF-8 encoding for Python to handle Unicode characters
+        $env:PYTHONIOENCODING = "utf-8"
+        python fuwarp-windows.py
 
     - name: Test path construction
       shell: pwsh
       run: |
+        # Set UTF-8 encoding for Python
+        $env:PYTHONIOENCODING = "utf-8"
+
         python -c @"
         import os
         import sys
-        sys.path.insert(0, '.')
-        from fuwarp_windows import FuwarpWindows
+        # Import the module by executing the file directly to get the class
+        exec(open('fuwarp-windows.py').read(), globals())  # This loads FuwarpWindows class
 
         # Test that paths are properly constructed for Windows
         fw = FuwarpWindows(mode='status', debug=True)
@@ -76,8 +85,8 @@ jobs:
             assert '/' not in path_after_drive, f'Mixed separators found: {path}'
 
         # Test that CLOUDFLARE_WARP_DIR uses proper separators
-        import fuwarp_windows
-        warp_dir = fuwarp_windows.CLOUDFLARE_WARP_DIR
+        # CLOUDFLARE_WARP_DIR is a global variable that was loaded
+        warp_dir = CLOUDFLARE_WARP_DIR
         print(f'WARP dir: {warp_dir}')
 
         if ':' in warp_dir:
@@ -90,10 +99,13 @@ jobs:
     - name: Test certificate download with mock
       shell: pwsh
       run: |
+        # Set UTF-8 encoding for Python
+        $env:PYTHONIOENCODING = "utf-8"
+
         python -c @"
         import sys
-        sys.path.insert(0, '.')
-        from fuwarp_windows import FuwarpWindows
+        # Import the module by executing the file directly
+        exec(open('fuwarp-windows.py').read(), globals())
 
         fw = FuwarpWindows(mode='status', debug=True)
         result = fw.download_certificate()
@@ -104,13 +116,16 @@ jobs:
     - name: Test specific bug fix - same file copy protection
       shell: pwsh
       run: |
+        # Set UTF-8 encoding for Python
+        $env:PYTHONIOENCODING = "utf-8"
+
         # Test that we don't try to copy a file to itself
         python -c @"
         import os
         import sys
         import tempfile
-        sys.path.insert(0, '.')
-        from fuwarp_windows import FuwarpWindows
+        # Import the module by executing the file directly
+        exec(open('fuwarp-windows.py').read(), globals())
 
         fw = FuwarpWindows(mode='status', debug=True)
 


### PR DESCRIPTION
## Summary
- Adds automated Windows testing using GitHub Actions free runners
- Tests the fuwarp-windows.py script without requiring actual WARP installation
- Validates the recent path separator bug fixes work correctly

## When Tests Run
The workflow triggers automatically when:
- `fuwarp-windows.py` is modified
- The workflow file itself (`.github/workflows/windows-test.yml`) is modified
- On pushes to main or pull requests affecting these files
- Can also be triggered manually via workflow_dispatch

This ensures tests only run when relevant changes are made, not for unrelated repo updates.

## What's Tested
1. **Basic functionality**: Script imports, --help, and --version
2. **Path construction**: Ensures no mixed forward/backward slashes on Windows
3. **Certificate operations**: Tests download with mocked warp-cli
4. **Bug fix validation**: Verifies same-file copy protection works

## Implementation Details
- Uses `windows-latest` runner (currently Windows Server 2022)
- Creates mock `warp-cli.bat` to simulate WARP being installed
- Uses PowerShell for Windows-native command execution
- No Python version matrix - uses default Python on Windows runner (basic file operations work the same across Python 3.x)

## Test Output
The workflow will show:
- Whether paths are constructed correctly for Windows
- If the mock certificate download succeeds
- Protection against the "same file" error that was reported

This gives us confidence that the Windows version works without needing a Windows machine locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)