### PR TITLE
Detect and fix suspiciously small CA bundles

### DIFF
--- a/test_suite/test_suspicious_bundles.py
+++ b/test_suite/test_suspicious_bundles.py
@@ -1,0 +1,170 @@
+"""
+Tests for detecting suspiciously small CA bundles.
+
+These tests focus on the helper heuristics introduced to catch cases where
+users accidentally point full-bundle env vars at a single WARP CA cert.
+"""
+import pytest
+
+from helpers import MockBuilder, mock_fuwarp_environment, FuwarpTestCase
+from unittest.mock import patch, ANY
+import mock_data
+
+
+class TestSuspiciousBundles(FuwarpTestCase):
+    def test_is_suspicious_when_single_cert_file(self):
+        """A file with a single PEM certificate is suspicious as a full bundle."""
+        small_path = f"{mock_data.HOME_DIR}/small-bundle.pem"
+
+        mock_config = (
+            MockBuilder()
+            .with_file(small_path, mock_data.MOCK_CERTIFICATE)
+            .build()
+        )
+
+        with mock_fuwarp_environment(mock_config):
+            instance = self.create_fuwarp_instance()
+            suspicious, reason = instance.is_suspicious_full_bundle(small_path, None)
+            assert suspicious is True
+            assert "contains 1 certificate" in reason
+
+    def test_is_not_suspicious_when_many_certs(self):
+        """A bundle containing many certs should not be flagged suspicious."""
+        bundle_path = f"{mock_data.HOME_DIR}/big-bundle.pem"
+        # Build a bundle with 5 certs and some extra size
+        content = (mock_data.SAMPLE_CA_BUNDLE + "\n") * 5
+
+        mock_config = (
+            MockBuilder()
+            .with_file(bundle_path, content)
+            .build()
+        )
+
+        with mock_fuwarp_environment(mock_config):
+            instance = self.create_fuwarp_instance()
+            suspicious, reason = instance.is_suspicious_full_bundle(bundle_path, None)
+            assert suspicious is False
+
+    def test_npm_repoint_on_suspicious_existing(self):
+        """When npm cafile is a suspicious single-cert file, repoint to managed bundle in install mode."""
+        npm_current = f"{mock_data.HOME_DIR}/npm-cafile.pem"
+        npm_managed = f"{mock_data.HOME_DIR}/.cloudflare-warp/npm/ca-bundle.pem"
+
+        mock_config = (
+            MockBuilder()
+            .with_env_var('HOME', mock_data.HOME_DIR)
+            .with_tools('node', 'npm')
+            .with_file(npm_current, mock_data.MOCK_CERTIFICATE)
+            .with_file('/etc/ssl/cert.pem', mock_data.SAMPLE_CA_BUNDLE)
+            # npm config get cafile
+            .with_subprocess_response(stdout=npm_current)
+            # npm config set cafile <managed>
+            .with_subprocess_response(returncode=0)
+            .build()
+        )
+
+        with mock_fuwarp_environment(mock_config) as mocks:
+            instance = self.create_fuwarp_instance(mode='install')
+            instance.setup_node_cert()  # calls setup_npm_cafile internally
+            # Assert npm set called with managed path
+            from helpers import assert_subprocess_called_with
+            assert_subprocess_called_with(
+                mocks['subprocess'],
+                ['npm', 'config', 'set', 'cafile', npm_managed]
+            )
+
+    def test_gcloud_repoint_on_suspicious_existing(self):
+        """When gcloud custom_ca_certs_file is suspicious, repoint to managed bundle in install mode."""
+        gcloud_current = f"{mock_data.HOME_DIR}/gcloud-ca.pem"
+        gcloud_managed = f"{mock_data.HOME_DIR}/.config/gcloud/certs/combined-ca-bundle.pem"
+
+        mock_config = (
+            MockBuilder()
+            .with_env_var('HOME', mock_data.HOME_DIR)
+            .with_tools('gcloud')
+            .with_file(gcloud_current, mock_data.MOCK_CERTIFICATE)
+            .with_file('/etc/ssl/cert.pem', mock_data.SAMPLE_CA_BUNDLE)
+            # gcloud config get
+            .with_subprocess_response(stdout=gcloud_current)
+            # gcloud config set
+            .with_subprocess_response(returncode=0)
+            .build()
+        )
+
+        with mock_fuwarp_environment(mock_config) as mocks:
+            instance = self.create_fuwarp_instance(mode='install')
+            instance.setup_gcloud_cert()
+            from helpers import assert_subprocess_called_with
+            assert_subprocess_called_with(
+                mocks['subprocess'],
+                ['gcloud', 'config', 'set', 'core/custom_ca_certs_file', gcloud_managed]
+            )
+
+    def test_git_setup_repoint_on_suspicious_existing(self):
+        """When git http.sslCAInfo is suspicious, configure it to managed bundle in install mode."""
+        git_current = f"{mock_data.HOME_DIR}/git-ca.pem"
+        git_managed = f"{mock_data.HOME_DIR}/.cloudflare-warp/git/ca-bundle.pem"
+
+        mock_config = (
+            MockBuilder()
+            .with_env_var('HOME', mock_data.HOME_DIR)
+            .with_tools('git')
+            .with_file(git_current, mock_data.MOCK_CERTIFICATE)
+            .with_file('/etc/ssl/cert.pem', mock_data.SAMPLE_CA_BUNDLE)
+            # git config --global http.sslCAInfo (get)
+            .with_subprocess_response(stdout=git_current)
+            # git config --global http.sslCAInfo <managed>
+            .with_subprocess_response(returncode=0)
+            .build()
+        )
+
+        with mock_fuwarp_environment(mock_config) as mocks:
+            instance = self.create_fuwarp_instance(mode='install')
+            instance.setup_git_cert()
+            from helpers import assert_subprocess_called_with
+            assert_subprocess_called_with(
+                mocks['subprocess'],
+                ['git', 'config', '--global', 'http.sslCAInfo', git_managed]
+            )
+
+    def test_curl_repoint_on_suspicious_existing(self):
+        """When CURL_CA_BUNDLE is suspicious, repoint to managed bundle in install mode."""
+        curl_current = f"{mock_data.HOME_DIR}/curl-ca.pem"
+        curl_managed = f"{mock_data.HOME_DIR}/.cloudflare-warp/curl/ca-bundle.pem"
+
+        mock_config = (
+            MockBuilder()
+            .with_env_var('HOME', mock_data.HOME_DIR)
+            .with_env_var('SHELL', '/bin/zsh')
+            .with_env_var('CURL_CA_BUNDLE', curl_current)
+            .with_tools('curl')
+            .with_file(curl_current, mock_data.MOCK_CERTIFICATE)
+            .with_file('/etc/ssl/cert.pem', mock_data.SAMPLE_CA_BUNDLE)
+            .build()
+        )
+
+        with mock_fuwarp_environment(mock_config):
+            instance = self.create_fuwarp_instance(mode='install')
+            with patch.object(type(instance), 'add_to_shell_config', wraps=instance.add_to_shell_config) as add_cfg:
+                instance.setup_curl_cert()
+                # Ensure we repointed CURL_CA_BUNDLE to managed path
+                add_cfg.assert_any_call('CURL_CA_BUNDLE', curl_managed, ANY)
+
+    def test_git_status_suspicious_returns_issue(self):
+        """Git status returns an issue when http.sslCAInfo is a suspicious bundle."""
+        git_current = f"{mock_data.HOME_DIR}/git-ca.pem"
+
+        mock_config = (
+            MockBuilder()
+            .with_env_var('HOME', mock_data.HOME_DIR)
+            .with_tools('git')
+            .with_file(git_current, mock_data.MOCK_CERTIFICATE)
+            # git config --global http.sslCAInfo (get)
+            .with_subprocess_response(stdout=git_current)
+            .build()
+        )
+
+        with mock_fuwarp_environment(mock_config):
+            instance = self.create_fuwarp_instance(mode='status')
+            has_issues = instance.check_git_status(None)
+            assert has_issues is True


### PR DESCRIPTION
## Summary
Fixes #8

Users who attempt manual TLS fixes often incorrectly set environment variables (like `REQUESTS_CA_BUNDLE`, npm `cafile`) to point at a single WARP CA certificate instead of a full bundle containing all public CAs. This causes confusing TLS failures when accessing endpoints that aren't subject to TLS inspection.

- Add `is_suspicious_full_bundle()` heuristic to detect bundles with ≤2 certificates or <50KB
- Update npm, Python, gcloud setup to detect and repoint suspicious bundles to managed full bundles
- Add Git tool support with `http.sslCAInfo` configuration
- Add curl bundle detection via `CURL_CA_BUNDLE` env var
- Update status checks to warn about suspicious bundles with actionable guidance
- Include tests for suspicious bundle detection

## Test plan
- [ ] Set `REQUESTS_CA_BUNDLE` to a file containing only the WARP cert, run `./fuwarp.py` and verify warning is shown
- [ ] Run `./fuwarp.py --fix` and verify it creates a full bundle and repoints the env var
- [ ] Run tests: `cd test_suite && python -m pytest test_suspicious_bundles.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)