### PR TITLE
Fix documentation inaccuracies and outdated information (fixes #22, #23)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,25 @@ fuwarp (Cloudflare WARP Certificate Fixer Upper) is a Python script that automat
 
 ### Testing
 
-The script doesn't have a formal test suite. Manual testing involves:
-- Running in status mode to verify detection: `./fuwarp.py`
-- Running with `--fix` to test installation on different tool configurations
+The project has a pytest-based test suite in `test_suite/`:
+
+```bash
+# Run all tests
+cd test_suite
+source .venv/bin/activate  # or create with: uv venv && uv pip install -r requirements.txt
+python -m pytest test_fuwarp_integration.py -v
+
+# Run specific test classes
+python -m pytest test_fuwarp_integration.py::TestStatusFunctionContracts -v
+python -m pytest test_fuwarp_integration.py::TestCodeQuality -v
+```
+
+Key test categories:
+- **TestCertificateManagement**: Certificate download and validation
+- **TestToolSetup**: Tool-specific certificate setup workflows
+- **TestStatusFunctionContracts**: Ensures all `check_*_status()` functions return booleans
+- **TestCodeQuality**: Static analysis to catch unsafe certificate append patterns
+- **TestCertificateAppending**: Tests for safe PEM file handling (issue #13 fix)
 
 ## Architecture Overview
 
@@ -57,7 +73,7 @@ The script follows a modular architecture with these key components:
    - Each supported tool has its own `setup_*_cert()` function
    - Functions check current configuration before making changes
    - Handle permission issues by suggesting user-writable alternatives
-   - Support for: Node.js/npm, Python, gcloud, Java/JVM, DBeaver, wget, Podman, Rancher, Android Emulator
+   - Support for: Node.js/npm, Python, gcloud, Git, curl, Java/JVM, jenv, Gradle, DBeaver, wget, Podman, Rancher, Colima, Android Emulator
    - Tools can be selectively processed using `--tools` option with keys or tags
 
 4. **Certificate Verification**:

--- a/README.md
+++ b/README.md
@@ -98,11 +98,15 @@ Something amiss or not quite right? Please post the full output of a run to an i
 - **Node.js/npm**: configures `NODE_EXTRA_CA_CERTS` for Node.js and the cafile setting for npm
 - **Python**: sets the `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, and `CURL_CA_BUNDLE` environment variables
 - **gcloud**: configures the `core/custom_ca_certs_file` for the Google Cloud `gcloud` CLI
+- **Git**: configures Git to use the custom certificate bundle via `http.sslCAInfo`
+- **curl**: configures `CURL_CA_BUNDLE` environment variable for curl
 - **Java/JVM**: adds the Cloudflare certificate to any found Java keystore (cacerts)
+- **jenv**: adds the Cloudflare certificate to all jenv-managed Java installations
 - **DBeaver**: targets the bundled JRE and adds the certificate to its keystore
 - **wget**: configures the `ca_certificate` in the `.wgetrc` file
 - **Podman**: installs certificate in Podman VM's trust store
 - **Rancher Desktop**: installs certificate in Rancher VM's trust store
+- **Colima**: installs certificate in Colima VM's trust store
 - **Android Emulator**: helps install certificate on running Android emulators
 - **Gradle**: sets `systemProp` entries in `gradle.properties` (respecting `GRADLE_USER_HOME`) for the WARP certificate.
  

--- a/fuwarp.py
+++ b/fuwarp.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from datetime import datetime
 
 # Version and metadata
-__description__ = "Cloudflare WARP Certificate Fixer Upper for macOS"
+__description__ = "Cloudflare WARP Certificate Fixer Upper for macOS and Linux"
 __author__ = "Ingersoll & Claude"
 
 
@@ -2871,7 +2871,6 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             self.print_status("Additional Tools (not yet automated):")
             self.print_info("  - RubyGems/Bundler: May work with SSL_CERT_FILE environment variable")
             self.print_info("  - PHP/Composer: May need CURL_CA_BUNDLE and php.ini configuration")
-            self.print_info("  - Git: May need 'git config --global http.sslCAInfo' setting")
             self.print_info("  - Firefox: Uses its own certificate store in profile")
             self.print_info("  - Other Homebrew tools: May need individual configuration")
             print()


### PR DESCRIPTION
## Summary
Fixes multiple documentation inaccuracies discovered during code review.

## Changes

### fuwarp.py
- **Issue #22**: Update `__description__` from "for macOS" to "for macOS and Linux" since the code extensively supports Linux (WSL, devcontainers, Linux certificate paths)
- **Issue #23**: Remove Git from "Additional Tools (not yet automated)" section since it has fully implemented `setup_git_cert()` and `check_git_status()` functions

### README.md
- Add missing tools to Linux/macOS supported list:
  - **Git**: configures `http.sslCAInfo`
  - **curl**: configures `CURL_CA_BUNDLE`
  - **jenv**: handles jenv-managed Java installations
  - **Colima**: installs certificate in Colima VM's trust store

### CLAUDE.md
- Replace outdated "no formal test suite" section with actual pytest documentation
- Add commands to run tests and list key test categories
- Add missing tools to supported list: Git, curl, jenv, Gradle, Colima

## Test plan
- [x] All 34 integration tests pass
- [ ] CI workflow passes

Fixes #22, fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)