### PR TITLE
Refactor: Extract helper, standardize messaging, fix bare excepts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,12 @@ Key test categories:
 - **TestCertificateManagement**: Certificate download and validation
 - **TestToolSetup**: Tool-specific certificate setup workflows
 - **TestStatusFunctionContracts**: Ensures all `check_*_status()` functions return booleans
-- **TestCodeQuality**: Static analysis to catch unsafe certificate append patterns
+- **TestCodeQuality**: Static analysis tests that enforce code standards:
+  - No unsafe certificate appends (use `safe_append_certificate()`)
+  - No unused global variables
+  - Consistent messaging ("Configuring" not "Setting up")
+  - No bare `except:` clauses (use `except Exception:`)
+- **TestBundleCreation**: Tests for `create_bundle_with_system_certs()` helper
 - **TestCertificateAppending**: Tests for safe PEM file handling (issue #13 fix)
 
 ## Architecture Overview
@@ -76,7 +81,9 @@ The script follows a modular architecture with these key components:
    - Support for: Node.js/npm, Python, gcloud, Git, curl, Java/JVM, jenv, Gradle, DBeaver, wget, Podman, Rancher, Colima, Android Emulator
    - Tools can be selectively processed using `--tools` option with keys or tags
 
-4. **Certificate Verification**:
+4. **Certificate Helpers**:
+   - `create_bundle_with_system_certs(path)`: Creates a CA bundle initialized with system certificates from `/etc/ssl/cert.pem` (macOS) or `/etc/ssl/certs/ca-certificates.crt` (Linux)
+   - `safe_append_certificate(cert, target)`: Safely appends a certificate to a bundle file, ensuring proper PEM formatting
    - `certificate_exists_in_file()`: Checks if certificate already exists in bundle files
    - `verify_connection()`: Tests if tools can connect through WARP
 

--- a/WINDOWS_REFACTORING_NOTES.md
+++ b/WINDOWS_REFACTORING_NOTES.md
@@ -20,15 +20,27 @@ until the Windows refactoring is complete.
 - Delete unused globals listed above
 - Check for dead functions not in registry (similar to `setup_curl_cert` in fuwarp.py)
 
-### 2. Helper Function Extraction
-- Windows equivalent of `create_bundle_with_system_certs()` (once implemented in fuwarp.py)
-- May need different system paths for Windows
+### 2. Helper Function Extraction (PR #29)
+The `create_bundle_with_system_certs()` helper was implemented in fuwarp.py:
+- Centralizes system CA bundle detection logic
+- Returns bool to indicate if system certs were found
+- Windows equivalent needed with different system paths:
+  - Windows doesn't have `/etc/ssl/cert.pem` or `/etc/ssl/certs/ca-certificates.crt`
+  - May need to use Windows Certificate Store APIs or certifi package
+  - Consider using `certifi.where()` if available
 
-### 3. Message Standardization
-- Use "Configuring <tool> certificate..." consistently (not "Setting up")
+### 3. Message Standardization (PR #29)
+- Changed 16 occurrences of "Setting up X certificate" to "Configuring X certificate"
+- Apply same pattern to fuwarp_windows.py for consistency
+- Check with: `grep -n "Setting up" fuwarp_windows.py`
 
-### 4. Exception Handling
-- Replace bare `except:` with specific exceptions like `subprocess.SubprocessError`
+### 4. Exception Handling (PR #29)
+- Replaced 28 bare `except:` with `except Exception:` in fuwarp.py
+- Rationale: `except Exception:` catches all "normal" exceptions but allows:
+  - `KeyboardInterrupt` (Ctrl+C) to propagate
+  - `SystemExit` to propagate
+- Apply same pattern to fuwarp_windows.py
+- Check with: `grep -n "except:" fuwarp_windows.py | grep -v "Exception"`
 
 ## Windows-Specific Considerations
 


### PR DESCRIPTION
## Summary

Test-first refactoring with code quality improvements:

- **Extract `create_bundle_with_system_certs()` helper** - Reduces code duplication across 9 call sites, centralizing system CA bundle detection logic
- **Standardize setup function messaging** - Changed 16 occurrences of "Setting up X certificate" to "Configuring X certificate" for consistency
- **Replace bare except clauses with `except Exception:`** - Fixes 28 locations where bare `except:` was used, allowing KeyboardInterrupt/SystemExit to propagate (users can now Ctrl+C out of operations)
- **Add regression tests** - New tests prevent reintroduction of these issues
- **Update Windows refactoring notes** - Documents patterns to apply to fuwarp_windows.py

### Changes

| Category | Count | Description |
|----------|-------|-------------|
| Code duplication | 9 sites | Replaced with `create_bundle_with_system_certs()` helper |
| Messaging | 16 occurrences | "Setting up" → "Configuring" |
| Exception handling | 28 locations | `except:` → `except Exception:` |
| New tests | 3 tests | TestBundleCreation class + 2 code quality tests |

### Files Changed

- `fuwarp.py` - Helper extraction, messaging, exception fixes
- `test_suite/test_fuwarp_integration.py` - New tests for regression prevention
- `CLAUDE.md` - Documentation for new helper function
- `WINDOWS_REFACTORING_NOTES.md` - Updated with patterns to apply to Windows

### Follow-up: Windows Port

The `WINDOWS_REFACTORING_NOTES.md` file documents what needs to be applied to `fuwarp_windows.py`:
- Helper function extraction (Windows needs different system cert paths)
- Message standardization (check for "Setting up" patterns)
- Exception handling (replace bare `except:` clauses)

## Test plan

- [x] All 42 existing tests pass
- [x] New tests verify helper function behavior
- [x] New tests catch inconsistent messaging
- [x] New tests catch bare except clauses
- [x] Python syntax verified with py_compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)