### PR TITLE
Fix: npm cafile not fixed when NODE_EXTRA_CA_CERTS already contains cert

### DIFF
--- a/fuwarp.py
+++ b/fuwarp.py
@@ -1106,8 +1106,8 @@ class FuwarpPython:
             if os.path.exists(node_extra_ca_certs):
                 # Check if the file contains our certificate using normalized comparison
                 if self.certificate_exists_in_file(CERT_PATH, node_extra_ca_certs):
-                    # Certificate already exists, nothing to do
-                    return
+                    # Certificate already exists in NODE_EXTRA_CA_CERTS, skip to npm setup
+                    pass
                 else:
                     needs_setup = True
                     self.print_info("Configuring Node.js certificate...")


### PR DESCRIPTION
## Summary

- Fixed bug where `--fix` didn't address the npm cafile suspicious bundle warning when NODE_EXTRA_CA_CERTS already contained the WARP certificate
- Changed early `return` to `pass` in `setup_node_cert()` so npm setup logic is always reached
- Added regression test for issue #37

## Problem

When running `--debug`, fuwarp correctly warned about the npm cafile containing only 1 certificate:

```
[WARN]   ⚠ npm cafile looks suspiciously small (contains 1 certificate(s), size=29374B)
[ACTION]     Run with --fix to repoint npm to a full CA bundle
```

But `--fix` never addressed this because `setup_node_cert()` had an early `return` when the certificate already existed in `NODE_EXTRA_CA_CERTS`, skipping the call to `setup_npm_cafile()`.

## Root Cause

In `setup_node_cert()` at lines 1108-1110:
```python
if self.certificate_exists_in_file(CERT_PATH, node_extra_ca_certs):
    # Certificate already exists, nothing to do
    return  # <-- Early return skipped setup_npm_cafile()!
```

## Fix

Changed `return` to `pass` so execution continues to the npm setup logic at line 1173-1175.

## Test plan

- [x] Added regression test `test_npm_repoint_even_when_node_extra_ca_certs_already_has_cert`
- [x] All 70 existing tests pass

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)