### PR TITLE
feat: Add CalVer versioning with semantic update checks

### DIFF
--- a/.github/workflows/stamp-version.yml
+++ b/.github/workflows/stamp-version.yml
@@ -1,0 +1,79 @@
+name: Stamp Version
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'fuwarp.py'
+      - 'fuwarp_windows.py'
+
+jobs:
+  stamp-version:
+    runs-on: ubuntu-latest
+    # Only run if the commit was NOT made by this workflow (avoid infinite loop)
+    if: ${{ !contains(github.event.head_commit.message, '[skip-version]') && github.event.head_commit.author.name != 'github-actions[bot]' }}
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 0
+
+    - name: Get today's date and determine version
+      id: version
+      run: |
+        TODAY=$(date -u +%Y.%-m.%-d)
+        echo "date=$TODAY" >> $GITHUB_OUTPUT
+
+        # Check current version in the file
+        CURRENT_VERSION=$(grep -oP '__version__\s*=\s*["'"'"']\K[0-9.]+' fuwarp.py || echo "")
+        echo "Current version: $CURRENT_VERSION"
+
+        # Determine new version based on current
+        if [[ "$CURRENT_VERSION" == "$TODAY" ]]; then
+          # Already today's base version, add .1
+          NEW_VERSION="$TODAY.1"
+        elif [[ "$CURRENT_VERSION" =~ ^${TODAY}\.([0-9]+)$ ]]; then
+          # Already has a patch number, increment it
+          PATCH=$((${BASH_REMATCH[1]} + 1))
+          NEW_VERSION="$TODAY.$PATCH"
+        else
+          # Different date or no version, use today's date
+          NEW_VERSION="$TODAY"
+        fi
+
+        echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+        echo "New version will be: $NEW_VERSION"
+
+    - name: Update version in fuwarp.py
+      run: |
+        sed -i 's/^__version__\s*=\s*["'"'"'][0-9.]*["'"'"']/__version__ = "${{ steps.version.outputs.new_version }}"/' fuwarp.py
+
+        # Verify the change
+        echo "Updated fuwarp.py version:"
+        grep '__version__' fuwarp.py
+
+    - name: Update version in fuwarp_windows.py
+      run: |
+        if [ -f fuwarp_windows.py ] && grep -q '__version__' fuwarp_windows.py; then
+          sed -i 's/^__version__\s*=\s*["'"'"'][0-9.]*["'"'"']/__version__ = "${{ steps.version.outputs.new_version }}"/' fuwarp_windows.py
+          echo "Updated fuwarp_windows.py version:"
+          grep '__version__' fuwarp_windows.py
+        else
+          echo "fuwarp_windows.py not found or has no __version__, skipping"
+        fi
+
+    - name: Commit version stamp
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
+        # Only commit if there are changes
+        if git diff --quiet; then
+          echo "No version changes needed"
+        else
+          git add fuwarp.py fuwarp_windows.py 2>/dev/null || git add fuwarp.py
+          git commit -m "chore: stamp version ${{ steps.version.outputs.new_version }} [skip-version]"
+          git push
+          echo "Version stamped and pushed: ${{ steps.version.outputs.new_version }}"
+        fi

--- a/fuwarp_windows.py
+++ b/fuwarp_windows.py
@@ -18,6 +18,28 @@ import winreg
 from pathlib import Path
 from datetime import datetime
 
+# Version and metadata
+__description__ = "Cloudflare WARP Certificate Fixer Upper for Windows"
+__author__ = "Ingersoll & Claude"
+__version__ = "2025.12.18"  # CalVer: YYYY.MM.DD (auto-updated on release)
+
+
+def parse_calver(version_str):
+    """Parse CalVer version string into comparable tuple.
+
+    Args:
+        version_str: Version like "2025.12.18" or "2025.12.18.1"
+
+    Returns:
+        tuple: (year, month, day, patch) where patch is 0 for base versions
+    """
+    parts = version_str.split('.')
+    if len(parts) == 3:
+        return (int(parts[0]), int(parts[1]), int(parts[2]), 0)
+    elif len(parts) == 4:
+        return (int(parts[0]), int(parts[1]), int(parts[2]), int(parts[3]))
+    raise ValueError(f"Invalid CalVer format: {version_str}")
+
 
 def get_version_info():
     """Get version information from Git."""


### PR DESCRIPTION
## Summary

Implements Calendar Versioning (CalVer) to provide clearer version information and fix the confusing "newer version available" messages.

- Add `__version__` variable (YYYY.MM.DD format) to both fuwarp.py and fuwarp_windows.py
- Add `parse_calver()` helper function for version comparison
- Replace hash-based update check with semantic version comparison
  - Only warns when remote version is actually **newer** (not just different)
  - Shows both local and remote versions in warning message
- Add `--version`/`-V` CLI flag with git commit info
- Add GitHub Action to auto-stamp version on merge to main
  - Handles same-day releases with `.N` suffix (e.g., `2025.12.18.1`)
  - Uses `[skip-version]` marker to prevent infinite loops
- Add comprehensive CalVer tests

### Before

```
[WARN] A newer version of fuwarp.py is available!
```

(Confusing because "different" doesn't mean "newer")

### After

```
[WARN] A newer version of fuwarp.py is available!
[WARN]   Local:  2025.12.01
[WARN]   Remote: 2025.12.18
```

### New `--version` output

```
fuwarp 2025.12.18
  Git commit: abc1234 (2025-12-18)
  Branch: main
```

## Test plan

- [x] All 73 tests pass
- [x] `parse_calver()` correctly parses YYYY.MM.DD and YYYY.MM.DD.N formats
- [x] Version comparison works correctly (newer > older)
- [x] Update check only warns for genuinely newer versions
- [x] Network errors are handled gracefully
- [x] Missing version in remote file handled gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)