### PR TITLE
Rename fuwarp to fumitm across the codebase

### DIFF
--- a/.github/workflows/stamp-version.yml
+++ b/.github/workflows/stamp-version.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [main]
     paths:
-      - 'fuwarp.py'
-      - 'fuwarp_windows.py'
+      - 'fumitm.py'
+      - 'fumitm_windows.py'
 
 permissions:
   contents: write
@@ -29,7 +29,7 @@ jobs:
         echo "date=$TODAY" >> $GITHUB_OUTPUT
 
         # Check current version in the file
-        CURRENT_VERSION=$(grep -oP '__version__\s*=\s*["'"'"']\K[0-9.]+' fuwarp.py || echo "")
+        CURRENT_VERSION=$(grep -oP '__version__\s*=\s*["'"'"']\K[0-9.]+' fumitm.py || echo "")
         echo "Current version: $CURRENT_VERSION"
 
         # Determine new version based on current
@@ -48,22 +48,22 @@ jobs:
         echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
         echo "New version will be: $NEW_VERSION"
 
-    - name: Update version in fuwarp.py
+    - name: Update version in fumitm.py
       run: |
-        sed -i 's/^__version__\s*=\s*["'"'"'][0-9.]*["'"'"']/__version__ = "${{ steps.version.outputs.new_version }}"/' fuwarp.py
+        sed -i 's/^__version__\s*=\s*["'"'"'][0-9.]*["'"'"']/__version__ = "${{ steps.version.outputs.new_version }}"/' fumitm.py
 
         # Verify the change
-        echo "Updated fuwarp.py version:"
-        grep '__version__' fuwarp.py
+        echo "Updated fumitm.py version:"
+        grep '__version__' fumitm.py
 
-    - name: Update version in fuwarp_windows.py
+    - name: Update version in fumitm_windows.py
       run: |
-        if [ -f fuwarp_windows.py ] && grep -q '__version__' fuwarp_windows.py; then
-          sed -i 's/^__version__\s*=\s*["'"'"'][0-9.]*["'"'"']/__version__ = "${{ steps.version.outputs.new_version }}"/' fuwarp_windows.py
-          echo "Updated fuwarp_windows.py version:"
-          grep '__version__' fuwarp_windows.py
+        if [ -f fumitm_windows.py ] && grep -q '__version__' fumitm_windows.py; then
+          sed -i 's/^__version__\s*=\s*["'"'"'][0-9.]*["'"'"']/__version__ = "${{ steps.version.outputs.new_version }}"/' fumitm_windows.py
+          echo "Updated fumitm_windows.py version:"
+          grep '__version__' fumitm_windows.py
         else
-          echo "fuwarp_windows.py not found or has no __version__, skipping"
+          echo "fumitm_windows.py not found or has no __version__, skipping"
         fi
 
     - name: Commit version stamp
@@ -75,7 +75,7 @@ jobs:
         if git diff --quiet; then
           echo "No version changes needed"
         else
-          git add fuwarp.py fuwarp_windows.py 2>/dev/null || git add fuwarp.py
+          git add fumitm.py fumitm_windows.py 2>/dev/null || git add fumitm.py
           git commit -m "chore: stamp version ${{ steps.version.outputs.new_version }} [skip-version]"
           git push
           echo "Version stamped and pushed: ${{ steps.version.outputs.new_version }}"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -4,15 +4,15 @@ on:
   push:
     branches: [ main ]
     paths:
-      - 'fuwarp.py'
-      - 'fuwarp_windows.py'
+      - 'fumitm.py'
+      - 'fumitm_windows.py'
       - 'test_suite/**'
       - '.github/workflows/test-suite.yml'
   pull_request:
     branches: [ main ]
     paths:
-      - 'fuwarp.py'
-      - 'fuwarp_windows.py'
+      - 'fumitm.py'
+      - 'fumitm_windows.py'
       - 'test_suite/**'
       - '.github/workflows/test-suite.yml'
   workflow_dispatch:  # Allow manual triggering
@@ -22,25 +22,25 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      fuwarp: ${{ steps.filter.outputs.fuwarp }}
-      fuwarp_windows: ${{ steps.filter.outputs.fuwarp_windows }}
+      fumitm: ${{ steps.filter.outputs.fumitm }}
+      fumitm_windows: ${{ steps.filter.outputs.fumitm_windows }}
     steps:
     - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v3
       id: filter
       with:
         filters: |
-          fuwarp:
-            - 'fuwarp.py'
-            - 'test_suite/test_fuwarp_integration.py'
-          fuwarp_windows:
-            - 'fuwarp_windows.py'
-            - 'test_suite/test_fuwarp_windows.py'
+          fumitm:
+            - 'fumitm.py'
+            - 'test_suite/test_fumitm_integration.py'
+          fumitm_windows:
+            - 'fumitm_windows.py'
+            - 'test_suite/test_fumitm_windows.py'
 
   test-macos:
     runs-on: macos-latest
     needs: changes
-    if: needs.changes.outputs.fuwarp == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.changes.outputs.fumitm == 'true' || github.event_name == 'workflow_dispatch'
 
     steps:
     - uses: actions/checkout@v4
@@ -64,12 +64,12 @@ jobs:
       working-directory: test_suite
       run: |
         source .venv/bin/activate
-        python -m pytest test_fuwarp_integration.py -v --tb=short
+        python -m pytest test_fumitm_integration.py -v --tb=short
 
   test-linux:
     runs-on: ubuntu-latest
     needs: [changes, test-macos]  # Only run after macOS tests pass
-    if: needs.changes.outputs.fuwarp == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.changes.outputs.fumitm == 'true' || github.event_name == 'workflow_dispatch'
 
     steps:
     - uses: actions/checkout@v4
@@ -93,13 +93,13 @@ jobs:
       working-directory: test_suite
       run: |
         source .venv/bin/activate
-        python -m pytest test_fuwarp_integration.py -v --tb=short
+        python -m pytest test_fumitm_integration.py -v --tb=short
 
   test-windows:
     runs-on: windows-latest
     needs: [changes, test-macos]  # Only run after macOS tests pass
-    # Only run when fuwarp_windows.py or its tests change
-    if: needs.changes.outputs.fuwarp_windows == 'true' || github.event_name == 'workflow_dispatch'
+    # Only run when fumitm_windows.py or its tests change
+    if: needs.changes.outputs.fumitm_windows == 'true' || github.event_name == 'workflow_dispatch'
 
     steps:
     - uses: actions/checkout@v4
@@ -118,4 +118,4 @@ jobs:
     - name: Run Windows-specific tests
       working-directory: test_suite
       run: |
-        python -m pytest test_fuwarp_windows.py -v --tb=short
+        python -m pytest test_fumitm_windows.py -v --tb=short

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches: [ main ]
     paths:
-      - 'fuwarp_windows.py'
+      - 'fumitm_windows.py'
       - '.github/workflows/windows-test.yml'
   pull_request:
     branches: [ main ]
     paths:
-      - 'fuwarp_windows.py'
+      - 'fumitm_windows.py'
       - '.github/workflows/windows-test.yml'
   workflow_dispatch:  # Allow manual triggering if needed
 
@@ -50,15 +50,15 @@ jobs:
         $env:PYTHONIOENCODING = "utf-8"
 
         # Test direct script execution (not as a module import)
-        python fuwarp_windows.py --help
-        python fuwarp_windows.py --list-tools
+        python fumitm_windows.py --help
+        python fumitm_windows.py --list-tools
 
     - name: Test in status mode (read-only)
       shell: pwsh
       run: |
         # Set UTF-8 encoding for Python to handle Unicode characters
         $env:PYTHONIOENCODING = "utf-8"
-        python fuwarp_windows.py
+        python fumitm_windows.py
 
     - name: Test path construction
       shell: pwsh
@@ -70,10 +70,10 @@ jobs:
         import os
         import sys
         # Import the module by executing the file directly to get the class
-        exec(open('fuwarp_windows.py').read(), globals())  # This loads FuwarpWindows class
+        exec(open('fumitm_windows.py').read(), globals())  # This loads FumitmWindows class
 
         # Test that paths are properly constructed for Windows
-        fw = FuwarpWindows(mode='status', debug=True)
+        fw = FumitmWindows(mode='status', debug=True)
 
         # Test get_tool_bundle_path
         path = fw.get_tool_bundle_path('test')
@@ -105,9 +105,9 @@ jobs:
         python -c @"
         import sys
         # Import the module by executing the file directly
-        exec(open('fuwarp_windows.py').read(), globals())
+        exec(open('fumitm_windows.py').read(), globals())
 
-        fw = FuwarpWindows(mode='status', debug=True)
+        fw = FumitmWindows(mode='status', debug=True)
         result = fw.download_certificate()
         assert result == True, 'Certificate download should succeed with mock'
         print('Certificate download test passed')
@@ -125,9 +125,9 @@ jobs:
         import sys
         import tempfile
         # Import the module by executing the file directly
-        exec(open('fuwarp_windows.py').read(), globals())
+        exec(open('fumitm_windows.py').read(), globals())
 
-        fw = FuwarpWindows(mode='status', debug=True)
+        fw = FumitmWindows(mode='status', debug=True)
 
         # Create a temp file to test with
         with tempfile.NamedTemporaryFile(mode='w', suffix='.pem', delete=False) as tf:
@@ -152,9 +152,9 @@ jobs:
         import os
         import re
         import tempfile
-        exec(open('fuwarp_windows.py').read(), globals())
+        exec(open('fumitm_windows.py').read(), globals())
 
-        fw = FuwarpWindows(mode='install', debug=True)
+        fw = FumitmWindows(mode='install', debug=True)
 
         # Create certificate content (with trailing newline)
         cert_content = '-----BEGIN CERTIFICATE-----\nMIIEjTCCA3WgAwIBAgISA2Q1\n-----END CERTIFICATE-----\n'
@@ -207,9 +207,9 @@ jobs:
         import os
         import re
         import tempfile
-        exec(open('fuwarp_windows.py').read(), globals())
+        exec(open('fumitm_windows.py').read(), globals())
 
-        fw = FuwarpWindows(mode='install', debug=True)
+        fw = FumitmWindows(mode='install', debug=True)
 
         cert_content = '-----BEGIN CERTIFICATE-----\nMIIEjTCCA3WgAwIBAgISA2Q1\n-----END CERTIFICATE-----\n'
 
@@ -256,9 +256,9 @@ jobs:
         python -c @"
         import os
         import tempfile
-        exec(open('fuwarp_windows.py').read(), globals())
+        exec(open('fumitm_windows.py').read(), globals())
 
-        fw = FuwarpWindows(mode='install', debug=True)
+        fw = FumitmWindows(mode='install', debug=True)
 
         cert_content = '-----BEGIN CERTIFICATE-----\nMIIEjTCCA3WgAwIBAgISA2Q1\n-----END CERTIFICATE-----\n'
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Purpose
 
-fuwarp (Cloudflare WARP Certificate Fixer Upper) is a Python script that automatically fixes TLS certificate trust issues when using Cloudflare WARP with TLS decryption. The script configures various development tools to trust WARP's Gateway CA certificate.
+fumitm (Fix Up My Interception of TLS, Man) is a Python script that automatically fixes TLS certificate trust issues caused by MITM proxies such as Cloudflare WARP with TLS decryption. The script configures various development tools to trust the proxy's CA certificate.
 
 ## Key Commands
 
@@ -12,25 +12,25 @@ fuwarp (Cloudflare WARP Certificate Fixer Upper) is a Python script that automat
 
 ```bash
 # Check current certificate status (no changes made)
-./fuwarp.py
+./fumitm.py
 
 # Actually install/update certificates (makes changes)
-./fuwarp.py --fix
+./fumitm.py --fix
 
 # Run with detailed debug output for troubleshooting
-./fuwarp.py --debug
-./fuwarp.py --debug --fix  # Debug mode with fixes
+./fumitm.py --debug
+./fumitm.py --debug --fix  # Debug mode with fixes
 
 # Show help
-./fuwarp.py --help
+./fumitm.py --help
 
 # List all available tools and their tags
-./fuwarp.py --list-tools
+./fumitm.py --list-tools
 
 # Check/fix specific tools only
-./fuwarp.py --tools node --tools python  # Check Node.js and Python only
-./fuwarp.py --fix --tools node-npm,gcloud  # Fix Node.js/npm and gcloud only
-./fuwarp.py --fix --tools java,db  # Fix Java and database tools using tags
+./fumitm.py --tools node --tools python  # Check Node.js and Python only
+./fumitm.py --fix --tools node-npm,gcloud  # Fix Node.js/npm and gcloud only
+./fumitm.py --fix --tools java,db  # Fix Java and database tools using tags
 ```
 
 ### Testing
@@ -40,11 +40,11 @@ The project has a pytest-based test suite in `test_suite/`:
 ```bash
 # Run all tests
 cd test_suite
-uvx pytest test_fuwarp_integration.py -v
+uvx pytest test_fumitm_integration.py -v
 
 # Run specific test classes
-uvx pytest test_fuwarp_integration.py::TestStatusFunctionContracts -v
-uvx pytest test_fuwarp_integration.py::TestCodeQuality -v
+uvx pytest test_fumitm_integration.py::TestStatusFunctionContracts -v
+uvx pytest test_fumitm_integration.py::TestCodeQuality -v
 ```
 
 Key test categories:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# fuwarp (Cloudflare WARP Certificate Fixer Upper)
+# fumitm (MITM Certificate .. Fixer Upper)
 
-Script to automatically verify and fix Cloudflare Warp Gateway TLS distrust issues
+Script to automatically verify and fix MITM TLS distrust issues commonly afflicting corporate device users who are subject to traffic inspection via agents such as Cloudflare Warp, Netskope or ZScaler.
 
 ## Usage
 
@@ -8,80 +8,57 @@ Script to automatically verify and fix Cloudflare Warp Gateway TLS distrust issu
 
 ```bash
 # Download the script
-curl -LsSf https://raw.githubusercontent.com/aberoham/fuwarp/main/fuwarp.py -o fuwarp.py
-chmod +x ./fuwarp.py
+curl -LsSf https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py -o fumitm.py
+chmod +x ./fumitm.py
 
 # Check status (no changes made)
-./fuwarp.py
+./fumitm.py
 
 # Apply fixes
-./fuwarp.py --fix
+./fumitm.py --fix
 
 # Run with detailed debug output (useful for troubleshooting)
-./fuwarp.py --debug
+./fumitm.py --debug
 ```
 
 ### Windows
 
 ```powershell
 # Download the Windows-specific script
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/aberoham/fuwarp/main/fuwarp_windows.py" -OutFile "fuwarp_windows.py"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm_windows.py" -OutFile "fumitm_windows.py"
 
 # Check status (no changes made)
-python fuwarp_windows.py
+python fumitm_windows.py
 
 # Apply fixes to all supported tools
-python fuwarp_windows.py --fix
-
-# Fix only specific tools (can specify multiple)
-python fuwarp_windows.py --fix --tools node --tools python
-python fuwarp_windows.py --fix --tools node-npm,gcloud
-
-# List all available tools and their tags
-python fuwarp_windows.py --list-tools
-
-# Run with detailed debug/verbose output (useful for troubleshooting)
-python fuwarp_windows.py --debug
-python fuwarp_windows.py --verbose
-
-# Show help and all available commands
-python fuwarp_windows.py --help
+python fumitm_windows.py --fix
 ```
 
-#### Windows Command Line Options
+## FU MITM Rational
 
-- `-h, --help` - Show help message and exit
-- `--fix` - Actually make changes (default is status check only)
-- `--tools, --tool TOOLS` - Specific tools to check/fix (can be specified multiple times)
-  - Examples: `--tools node --tools python` or `--tools node,gcloud`
-- `--list-tools` - List all available tools and their tags
-- `--debug, --verbose` - Show detailed debug information
+When your organization runs a man-in-the-middle (MITM) gateway with TLS inspection enabled, the gateway intercepts and records virtually all HTTPS traffic for policy enforcement and security auditing. MITM gateways achieves this introspection by presenting their own root certificate to your TLS clients -- essentially performing sanctioned wiretapping on your TLS (aka SSL) connections.
 
-## FU Warp Rational
+Typically, MacOS and Windows themselves will automatically trust your MITM's certificate through system keychains. Most third-party development tools completely ignore these system certificates. Each tool maintains its own certificate bundle or looks for specific environment variables. This fragmentation creates endless annoying "certificate verify failed" errors across your toolchain whenever your MITM gateway's inspection is turned on.
 
-When your organization runs Cloudflare WARP Gateway with TLS inspection enabled, the gateway intercepts and records virtually all HTTPS traffic for policy enforcement and security auditing. WARP's Gateway achieves this introspection by presenting its own root certificate to your TLS clients -- essentially performing a sanctioned man-in-the-middle (MITM) attack on your TLS (aka SSL) connections.
+One particularly annoying detail is that simply pointing tools to your organization's MITM gateway certificate by itself rarely works. You often need to append the custom MITM CA to an existing bundle of public CAs, which quickly becomes a brittle process that needs repeating for each tool. 
 
-Typically, MacOS and Windows themselves will automatically trust WARP's certificate through system keychains. Most third-party development tools completely ignore these system certificates. Each tool maintains its own certificate bundle or looks for specific environment variables. This fragmentation creates endless annoying "certificate verify failed" errors across your toolchain whenever Warp Gateway's inspection is turned on.
+FU MITM!
 
-One particularly annoying detail is that simply pointing tools to your organization's WARP Gateway certificate by itself rarely works. You often need to append the custom WARP CA to an existing bundle of public CAs, which quickly becomes a brittle process that needs repeating for each tool. 
+## Don't Disable Your MITM
 
-FU Warp!
+Whilst the quick temporary workaround might be to toggle your MITM gateway OFF, this is incredibly distressing to any nearby Information Security professionals who will one day need to forensically examine dodgy dependencies or MCPs that have slipped onto your laptop.
 
-## Don't Disable Warp
-
-Whilst the quick temporary workaround might be to toggle Cloudflare Warp OFF, this is incredibly distressing to any nearby Information Security professionals who will one day need to forensically examine dodgy dependencies or MCPs that have slipped onto your laptop.
-
-The act of toggling Warp off also seriously hints that you have no clue what you're doing, as understanding TLS certificate-based trust is a critical concept underpinning modern vibe'n.
+The act of toggling your MITM off also seriously hints that you have no clue what you're doing, as understanding TLS certificate-based trust is a critical concept underpinning modern vibe'n.
 
 ## Requirements
 
 ### General
-- Cloudflare WARP must be installed and connected
-- `warp-cli` command must be available
+- Cloudflare WARP or Netskope Client must be installed and connected
+- `warp-cli` or `nsdiag` command must be available 
 - Python 3 (macOS, Windows/WSL)
 
 ### Windows-Specific
-- `warp-cli.exe` command must be available (typically installed with WARP)
+- `warp-cli.exe` or `nsdiag.exe` command must be available 
 - Administrator privileges may be required for some fixes
 
 ## Contribute
@@ -119,7 +96,7 @@ Something amiss or not quite right? Please post the full output of a run to an i
 
 #### Windows-Specific Notes
 
-The Windows version (`fuwarp_windows.py`) includes Windows-specific functionality:
+The Windows version (`fumitm_windows.py`) includes Windows-specific functionality:
 
 - Uses Windows Registry to locate certificates and configuration
 - Handles Windows paths and file permissions
@@ -128,9 +105,7 @@ The Windows version (`fuwarp_windows.py`) includes Windows-specific functionalit
 
 ### VS Code Devcontainers / WSL
 
-Fuwarp should auto-detect VS Code devcontainers and WSL environments where `warp-cli` is only available on the underlying host. Within these environments, fuwarp will guide the user where to obtain their Cloudflare cert and will skip slow verification tests.
-
-Fuwarp should auto-detect WSL environments where `warp-cli` is only available on the underlying Windows host. Within WSL, fuwarp will guide the user where to obtain their Cloudflare cert and will skip slow verification tests.
+Fumitm should auto-detect VS Code devcontainers and WSL environments where `warp-cli`/`nsdiag` is only available on the underlying host. Within these environments, fumitm will guide the user where to obtain their MITM cert and will skip slow verification tests.
 
 ## Installation Alternative
 
@@ -139,29 +114,29 @@ You can also run the script directly from the repository:
 ### Linux/macOS
 ```bash
 # Clone the repository
-git clone https://github.com/aberoham/fuwarp.git
-cd fuwarp
+git clone https://github.com/aberoham/fumitm.git
+cd fumitm
 
 # Run the script
-./fuwarp.py --fix
+./fumitm.py --fix
 ```
 
 ### Windows
 ```powershell
 # Clone the repository
-git clone https://github.com/aberoham/fuwarp.git
-cd fuwarp
+git clone https://github.com/aberoham/fumitm.git
+cd fumitm
 
 # Run the Windows-specific script
-python fuwarp_windows.py --fix
+python fumitm_windows.py --fix
 ```
 
 ## Troubleshooting
 
 If you encounter issues:
 
-1. Ensure WARP is connected: `warp-cli status`
-2. Run with debug output: `./fuwarp.py --debug` (Linux/macOS) or `python fuwarp_windows.py --debug` (Windows)
+1. Ensure your MITM is connected: `warp-cli status`, `nsdiag -f`
+2. Run with debug output: `./fumitm.py --debug` (Linux/macOS) or `python fumitm_windows.py --debug` (Windows)
 3. Check that Python 3 is properly installed and in your PATH
 4. Verify you have appropriate permissions for the tools you're trying to fix
 

--- a/WINDOWS_REFACTORING_NOTES.md
+++ b/WINDOWS_REFACTORING_NOTES.md
@@ -1,11 +1,11 @@
 # Windows Refactoring Notes
 
-This document tracks refactoring patterns applied to fuwarp.py that should
-also be applied to fuwarp_windows.py for consistency.
+This document tracks refactoring patterns applied to fumitm.py that should
+also be applied to fumitm_windows.py for consistency.
 
 ## Known Unused Globals (Pending Cleanup)
 
-The test suite has identified these unused global variables in fuwarp_windows.py:
+The test suite has identified these unused global variables in fumitm_windows.py:
 
 - `ALT_CERT_NAMES` - defined but never used
 - `SHELL_MODIFIED` - defined but never used (class uses `self.shell_modified`)
@@ -18,10 +18,10 @@ until the Windows refactoring is complete.
 
 ### 1. Dead Code Removal
 - Delete unused globals listed above
-- Check for dead functions not in registry (similar to `setup_curl_cert` in fuwarp.py)
+- Check for dead functions not in registry (similar to `setup_curl_cert` in fumitm.py)
 
 ### 2. Helper Function Extraction (PR #29)
-The `create_bundle_with_system_certs()` helper was implemented in fuwarp.py:
+The `create_bundle_with_system_certs()` helper was implemented in fumitm.py:
 - Centralizes system CA bundle detection logic
 - Returns bool to indicate if system certs were found
 - Windows equivalent needed with different system paths:
@@ -31,22 +31,22 @@ The `create_bundle_with_system_certs()` helper was implemented in fuwarp.py:
 
 ### 3. Message Standardization (PR #29)
 - Changed 16 occurrences of "Setting up X certificate" to "Configuring X certificate"
-- Apply same pattern to fuwarp_windows.py for consistency
-- Check with: `grep -n "Setting up" fuwarp_windows.py`
+- Apply same pattern to fumitm_windows.py for consistency
+- Check with: `grep -n "Setting up" fumitm_windows.py`
 
 ### 4. Exception Handling (PR #29)
-- Replaced 28 bare `except:` with `except Exception:` in fuwarp.py
+- Replaced 28 bare `except:` with `except Exception:` in fumitm.py
 - Rationale: `except Exception:` catches all "normal" exceptions but allows:
   - `KeyboardInterrupt` (Ctrl+C) to propagate
   - `SystemExit` to propagate
-- Apply same pattern to fuwarp_windows.py
-- Check with: `grep -n "except:" fuwarp_windows.py | grep -v "Exception"`
+- Apply same pattern to fumitm_windows.py
+- Check with: `grep -n "except:" fumitm_windows.py | grep -v "Exception"`
 
 ### 5. Performance: Pure Python Certificate Matching (PR #30)
 The `certificate_likely_exists_in_file()` function was refactored to use no subprocess calls:
 - **Before**: Used `openssl x509 -subject` to extract CN, then string search (1 subprocess call)
 - **After**: Pure Python extraction of first 100 chars of base64 content (0 subprocess calls)
-- Apply same pattern to fuwarp_windows.py
+- Apply same pattern to fumitm_windows.py
 
 The `certificate_exists_in_file()` function was simplified:
 - **Before**: In install mode, iterated through all certs in bundle and compared fingerprints via openssl (O(N) subprocess calls)
@@ -61,16 +61,16 @@ New regression tests added:
 ### 6. Update Check Functionality (PR #31)
 Added `check_for_updates()` method to compare local file hash against GitHub:
 - Uses `ssl._create_unverified_context()` since WARP certificate might not be configured yet
-- Fetches from `https://raw.githubusercontent.com/aberoham/fuwarp/main/fuwarp.py`
+- Fetches from `https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py`
 - Compares SHA256 hashes and warns user if update is available
-- Apply same pattern to fuwarp_windows.py with appropriate URL
+- Apply same pattern to fumitm_windows.py with appropriate URL
 
 ### 7. Connectivity-First Status Checks (PR #31)
 The `check_gcloud_status()` function was improved to verify actual connectivity:
 - **Before**: Flagged as issue if `core/custom_ca_certs_file` not configured
 - **After**: First calls `verify_connection("gcloud")` to test actual connectivity
 - If gcloud works (e.g., via system trust store), no issue is flagged
-- Apply same pattern to fuwarp_windows.py
+- Apply same pattern to fumitm_windows.py
 
 Added `verify_connection("gcloud")` handler:
 - Runs `gcloud config list --format=value(core.account)` to test connectivity

--- a/fumitm.py
+++ b/fumitm.py
@@ -153,7 +153,7 @@ CERT_PATH = os.path.expanduser("~/.cloudflare-ca.pem")
 SMALL_BUNDLE_MAX_CERTS = 2
 SMALL_BUNDLE_MAX_SIZE_BYTES = 50 * 1024  # 50KB
 
-class FuwarpPython:
+class FumitmPython:
     def __init__(self, mode='status', debug=False, selected_tools=None, cert_file=None, manual_cert=False, skip_verify=False):
         self.mode = mode
         self.debug = debug
@@ -353,7 +353,7 @@ class FuwarpPython:
             print(f"{BLUE}[DEBUG]{NC} {msg}", file=sys.stderr)
 
     def check_for_updates(self):
-        """Check if a newer version of fuwarp is available on GitHub.
+        """Check if a newer version of fumitm is available on GitHub.
 
         Uses CalVer version comparison instead of file hashes to avoid
         false positives from local modifications or formatting differences.
@@ -369,11 +369,11 @@ class FuwarpPython:
         try:
             # Use unverified SSL context - WARP might not be configured yet
             context = ssl._create_unverified_context()
-            url = "https://raw.githubusercontent.com/aberoham/fuwarp/main/fuwarp.py"
+            url = "https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py"
 
             self.print_debug(f"Checking for updates from {url}")
 
-            req = urllib.request.Request(url, headers={'User-Agent': 'fuwarp-update-check'})
+            req = urllib.request.Request(url, headers={'User-Agent': 'fumitm-update-check'})
             with urllib.request.urlopen(req, context=context, timeout=10) as response:
                 remote_content = response.read().decode('utf-8')
 
@@ -402,20 +402,20 @@ class FuwarpPython:
             if remote_tuple > local_tuple:
                 print()
                 self.print_warn("=" * 60)
-                self.print_warn("A newer version of fuwarp.py is available!")
+                self.print_warn("A newer version of fumitm.py is available!")
                 self.print_info(f"  Local:  {local_version}")
                 self.print_info(f"  Remote: {remote_version}")
                 self.print_warn("Update before running --fix to ensure best results:")
                 # Use -k to skip cert verification since user's curl may be broken
                 # (which is likely why they're running this script)
-                self.print_info("  curl -kLsSf https://raw.githubusercontent.com/aberoham/fuwarp/main/fuwarp.py -o fuwarp.py")
+                self.print_info("  curl -kLsSf https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py -o fumitm.py")
                 self.print_warn("=" * 60)
                 print()
                 return True
             elif remote_tuple < local_tuple:
                 self.print_debug(f"Running development version ({local_version} > {remote_version})")
             else:
-                self.print_debug("fuwarp.py is up to date")
+                self.print_debug("fumitm.py is up to date")
 
         except Exception as e:
             self.print_debug(f"Update check failed (this is OK): {e}")
@@ -1103,7 +1103,7 @@ class FuwarpPython:
         self.print_info("Devcontainer Detected - Manual Certificate Setup")
         self.print_info("=" * 70)
         print()
-        self.print_info("You're running fuwarp inside a devcontainer where warp-cli isn't available.")
+        self.print_info("You're running fumitm inside a devcontainer where warp-cli isn't available.")
         self.print_info("The WARP certificate needs to be obtained from your Windows host machine.")
         print()
         self.print_info("QUICKEST METHOD:")
@@ -1114,7 +1114,7 @@ class FuwarpPython:
         print()
         self.print_info("ALTERNATIVE METHOD:")
         self.print_info(f"1. Save the certificate to a file accessible from this container")
-        self.print_info(f"2. Run: ./fuwarp.py --fix --cert-file /path/to/cert.pem")
+        self.print_info(f"2. Run: ./fumitm.py --fix --cert-file /path/to/cert.pem")
         print()
         
         choice = input("Ready to paste? Press ENTER to continue, 'F' for file path, or 'Q' to quit: ").strip().upper()
@@ -1233,7 +1233,7 @@ class FuwarpPython:
                 warp_cert = self.get_certificate_from_user()
                 if not warp_cert:
                     self.print_error("Cannot proceed without a certificate in devcontainer environment")
-                    self.print_info("Tip: Run './fuwarp.py --fix' to set up the certificate")
+                    self.print_info("Tip: Run './fumitm.py --fix' to set up the certificate")
                     return False
         
         # Priority 4: Standard path - use warp-cli if available
@@ -1556,7 +1556,7 @@ class FuwarpPython:
             # Check if it points to our managed npm bundle (that's fine)
             npm_bundle = os.path.expanduser("~/.cloudflare-warp/npm/ca-bundle.pem")
             if current_cafile == npm_bundle:
-                return  # Points to fuwarp-managed bundle, that's OK
+                return  # Points to fumitm-managed bundle, that's OK
 
             # Check if file exists and contains WARP cert
             if os.path.exists(current_cafile) and self.certificate_exists_in_file(CERT_PATH, current_cafile):
@@ -1599,7 +1599,7 @@ class FuwarpPython:
             # Check if it points to our managed npm bundle (that's fine)
             npm_bundle = os.path.expanduser("~/.cloudflare-warp/npm/ca-bundle.pem")
             if current_cafile == npm_bundle:
-                return  # Points to fuwarp-managed bundle, that's OK
+                return  # Points to fumitm-managed bundle, that's OK
 
             # Check if file exists and contains WARP cert
             if os.path.exists(current_cafile) and self.certificate_exists_in_file(CERT_PATH, current_cafile):
@@ -2265,7 +2265,7 @@ class FuwarpPython:
                 self.print_warn("Failed to add certificate to DBeaver keystore (may require sudo)")
                 if len(result.stdout) > 0:
                     self.print_warn(f"Keytool response: {result.stdout.decode('utf-8')}")
-                self.print_warn("You may need to run: sudo ./fuwarp.py --fix")
+                self.print_warn("You may need to run: sudo ./fumitm.py --fix")
     
     def setup_wget_cert(self):
         """Setup wget certificate."""
@@ -2404,7 +2404,7 @@ class FuwarpPython:
                     self.print_info("Certificate in ~/.docker/certs.d/ will be available for future use")
             else:
                 self.print_info("Podman machine is not running")
-                self.print_info("Run 'podman machine start' then re-run fuwarp to install into VM")
+                self.print_info("Run 'podman machine start' then re-run fumitm to install into VM")
     
     def setup_rancher_cert(self):
         """Setup Rancher Desktop certificate.
@@ -2472,7 +2472,7 @@ class FuwarpPython:
                     self.print_info("Certificate in ~/.docker/certs.d/ will be available for future use")
             else:
                 self.print_info("Rancher Desktop is not running")
-                self.print_info("Start Rancher Desktop then re-run fuwarp to install into VM")
+                self.print_info("Start Rancher Desktop then re-run fumitm to install into VM")
     
     def setup_android_emulator_cert(self):
         """Setup Android Emulator certificate."""
@@ -3308,7 +3308,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     if result.returncode == 0:
                         self.print_info("  ✓ Certificate installed in running VM")
                     else:
-                        self.print_info("  - Certificate not in VM (run fuwarp --fix to install)")
+                        self.print_info("  - Certificate not in VM (run fumitm --fix to install)")
                 else:
                     self.print_info("  - Podman machine is stopped (certificate will be available on start)")
             except Exception:
@@ -3350,7 +3350,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     if result.returncode == 0:
                         self.print_info("  ✓ Certificate installed in running VM")
                     else:
-                        self.print_info("  - Certificate not in VM (run fuwarp --fix to install)")
+                        self.print_info("  - Certificate not in VM (run fumitm --fix to install)")
                 else:
                     self.print_info("  - Rancher Desktop is stopped (certificate will be available on start)")
             except Exception:
@@ -3592,7 +3592,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
         self.print_info("========")
         if has_issues:
             self.print_warn("Some configurations need attention.")
-            self.print_action("Run './fuwarp.py --fix' to fix the issues")
+            self.print_action("Run './fumitm.py --fix' to fix the issues")
         else:
             self.print_info("✓ All configured tools are properly set up for Cloudflare WARP")
         print()
@@ -3608,7 +3608,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             self.print_info("=================================================")
             
             if self.is_debug_mode():
-                self.print_debug(f"Fuwarp version: {VERSION_INFO['version']} (commit: {VERSION_INFO['commit']})")
+                self.print_debug(f"Fumitm version: {VERSION_INFO['version']} (commit: {VERSION_INFO['commit']})")
                 self.print_debug(f"Branch: {VERSION_INFO['branch']} | Date: {VERSION_INFO['date']}")
                 if VERSION_INFO['dirty']:
                     self.print_debug("Working directory has uncommitted changes")
@@ -3743,7 +3743,7 @@ def main():
 
     # Handle --version first
     if args.version:
-        print(f"fuwarp {__version__}")
+        print(f"fumitm {__version__}")
         version_info = VERSION_INFO
         if version_info['commit'] != 'unknown':
             print(f"  Git commit: {version_info['commit']} ({version_info['date']})")
@@ -3755,12 +3755,12 @@ def main():
     # Handle --list-tools
     if args.list_tools:
         # Create a temporary instance just to access the registry
-        temp_fuwarp = FuwarpPython()
+        temp_fumitm = FumitmPython()
         print("Available tools:")
-        for tool_key, tool_info in temp_fuwarp.tools_registry.items():
+        for tool_key, tool_info in temp_fumitm.tools_registry.items():
             tags_str = ', '.join(tool_info['tags'])
             print(f"  {tool_key:<10} - {tool_info['name']:<20} Tags: {tags_str}")
-        print("\nExamples: ./fuwarp.py --fix --tools node,python  or  ./fuwarp.py --fix --tools node-npm --tools gcp")
+        print("\nExamples: ./fumitm.py --fix --tools node,python  or  ./fumitm.py --fix --tools node-npm --tools gcp")
         sys.exit(0)
     
     # Process --tools argument
@@ -3773,8 +3773,8 @@ def main():
     # Determine mode
     mode = 'install' if args.fix else 'status'
     
-    # Create and run fuwarp instance
-    fuwarp = FuwarpPython(
+    # Create and run fumitm instance
+    fumitm = FumitmPython(
         mode=mode, 
         debug=args.debug, 
         selected_tools=selected_tools,
@@ -3782,7 +3782,7 @@ def main():
         manual_cert=args.manual_cert,
         skip_verify=args.skip_verify
     )
-    exit_code = fuwarp.main()
+    exit_code = fumitm.main()
     sys.exit(exit_code)
 
 

--- a/fumitm_windows.py
+++ b/fumitm_windows.py
@@ -157,7 +157,7 @@ SHELL_MODIFIED = False
 CERT_FINGERPRINT = ""  # Cache for certificate fingerprint
 
 
-class FuwarpWindows:
+class FumitmWindows:
     def __init__(
         self, mode="status", debug=False, selected_tools=None, use_warp_cli=False
     ):
@@ -2513,7 +2513,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
         self.print_info("========")
         if has_issues:
             self.print_warn("Some configurations need attention.")
-            self.print_action("Run 'python fuwarp_windows.py --fix' to fix the issues")
+            self.print_action("Run 'python fumitm_windows.py --fix' to fix the issues")
         else:
             self.print_info(
                 "✓ All configured tools are properly set up for Cloudflare WARP"
@@ -2532,7 +2532,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
 
             if self.is_debug_mode():
                 self.print_debug(
-                    f"Fuwarp version: {VERSION_INFO['version']} (commit: {VERSION_INFO['commit']})"
+                    f"Fumitm version: {VERSION_INFO['version']} (commit: {VERSION_INFO['commit']})"
                 )
                 self.print_debug(
                     f"Branch: {VERSION_INFO['branch']} | Date: {VERSION_INFO['date']}"
@@ -2643,11 +2643,11 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=f"""
 Examples:
-  python fuwarp_windows.py                    # Check status of all tools
-  python fuwarp_windows.py --fix              # Fix all detected issues
-  python fuwarp_windows.py --tools node       # Check only Node.js
-  python fuwarp_windows.py --fix --tools python,git  # Fix Python and Git only
-  python fuwarp_windows.py --list-tools       # Show available tools
+  python fumitm_windows.py                    # Check status of all tools
+  python fumitm_windows.py --fix              # Fix all detected issues
+  python fumitm_windows.py --tools node       # Check only Node.js
+  python fumitm_windows.py --fix --tools python,git  # Fix Python and Git only
+  python fumitm_windows.py --list-tools       # Show available tools
 
 {version_str} | Default: status check only (use --fix to make changes)
         """,
@@ -2701,14 +2701,14 @@ Examples:
     # Handle --list-tools first
     if args.list_tools:
         # Create a temporary instance just to access the registry
-        temp_fuwarp = FuwarpWindows()
+        temp_fumitm = FumitmWindows()
         print("Available tools:")
-        for tool_key, tool_info in temp_fuwarp.tools_registry.items():
+        for tool_key, tool_info in temp_fumitm.tools_registry.items():
             tags_str = ", ".join(tool_info["tags"])
             print(f"  {tool_key:<10} - {tool_info['name']:<25} Tags: {tags_str}")
-        print("\nExamples: python fuwarp_windows.py --fix --tools node,python")
+        print("\nExamples: python fumitm_windows.py --fix --tools node,python")
         print(
-            "          python fuwarp_windows.py --fix --tools node-npm --tools podman"
+            "          python fumitm_windows.py --fix --tools node-npm --tools podman"
         )
         sys.exit(0)
 
@@ -2722,14 +2722,14 @@ Examples:
     # Determine mode
     mode = "install" if args.fix else "status"
 
-    # Create and run fuwarp instance
-    fuwarp = FuwarpWindows(
+    # Create and run fumitm instance
+    fumitm = FumitmWindows(
         mode=mode,
         debug=args.debug,
         selected_tools=selected_tools,
         use_warp_cli=args.use_warp_cli,
     )
-    exit_code = fuwarp.main()
+    exit_code = fumitm.main()
     sys.exit(exit_code)
 
 

--- a/test_suite/README.md
+++ b/test_suite/README.md
@@ -1,12 +1,12 @@
-# fuwarp Test Suite
+# fumitm Test Suite
 
-Integration test suite for the fuwarp.py script
+Integration test suite for the fumitm.py script
 
 ## Overview
 
-This directory contains the integration test suite for fuwarp.py. The tests are maintained separately from the main script to preserve fuwarp.py as a standalone, single-file distribution.
+This directory contains the integration test suite for fumitm.py. The tests are maintained separately from the main script to preserve fumitm.py as a standalone, single-file distribution.
 
-The test suite provides comprehensive coverage of fuwarp's functionality through mocked external dependencies, ensuring reliability across different environments and configurations.
+The test suite provides comprehensive coverage of fumitm's functionality through mocked external dependencies, ensuring reliability across different environments and configurations.
 
 ## Quick Start
 
@@ -15,7 +15,7 @@ cd test_suite
 uv venv
 source .venv/bin/activate
 uv pip install -r requirements.txt
-python -m pytest test_fuwarp_integration.py -v
+python -m pytest test_fumitm_integration.py -v
 ```
 
 ## Installation
@@ -44,35 +44,35 @@ python -m pytest test_fuwarp_integration.py -v
 
 ```bash
 # Run all tests with verbose output
-python -m pytest test_fuwarp_integration.py -v
+python -m pytest test_fumitm_integration.py -v
 
 # Run tests quietly
-python -m pytest test_fuwarp_integration.py -q
+python -m pytest test_fumitm_integration.py -q
 
 # Run specific test class
-python -m pytest test_fuwarp_integration.py::TestCertificateManagement -v
+python -m pytest test_fumitm_integration.py::TestCertificateManagement -v
 
 # Run specific test method
-python -m pytest test_fuwarp_integration.py::TestToolSetup::test_node_npm_setup_workflow -v
+python -m pytest test_fumitm_integration.py::TestToolSetup::test_node_npm_setup_workflow -v
 
 # Stop on first failure
-python -m pytest test_fuwarp_integration.py -x
+python -m pytest test_fumitm_integration.py -x
 
 # Run with coverage report
-python -m pytest test_fuwarp_integration.py --cov=fuwarp --cov-report=term-missing
+python -m pytest test_fumitm_integration.py --cov=fumitm --cov-report=term-missing
 ```
 
 ### Debugging Tests
 
 ```bash
 # Show print statements and logging
-python -m pytest test_fuwarp_integration.py -v -s
+python -m pytest test_fumitm_integration.py -v -s
 
 # Drop into debugger on failure
-python -m pytest test_fuwarp_integration.py --pdb
+python -m pytest test_fumitm_integration.py --pdb
 
 # Show full traceback
-python -m pytest test_fuwarp_integration.py -v --tb=long
+python -m pytest test_fumitm_integration.py -v --tb=long
 ```
 
 ## Test Architecture
@@ -87,7 +87,7 @@ test_suite/
 ├── helpers.py                 # Test utilities and MockBuilder
 ├── mock_data.py              # Centralized mock responses
 ├── requirements.txt          # Test dependencies
-├── test_fuwarp_integration.py # Main test suite
+├── test_fumitm_integration.py # Main test suite
 └── README.md                 # This file
 ```
 
@@ -116,7 +116,7 @@ The test suite uses a comprehensive mocking approach:
 
 ### Adding Tests for New Tools
 
-When adding support for a new tool in fuwarp.py:
+When adding support for a new tool in fumitm.py:
 
 1. Add mock data to `mock_data.py`:
    ```python
@@ -134,8 +134,8 @@ When adding support for a new tool in fuwarp.py:
            .with_subprocess_response(stdout=mock_data.NEWTOOL_VERSION)
            .build())
        
-       with mock_fuwarp_environment(mock_config) as mocks:
-           instance = self.create_fuwarp_instance(mode='install')
+       with mock_fumitm_environment(mock_config) as mocks:
+           instance = self.create_fumitm_instance(mode='install')
            instance.setup_newtool_cert()
            
            # Verify tool was detected and configured
@@ -193,7 +193,7 @@ jobs:
         uv venv
         source .venv/bin/activate
         uv pip install -r requirements.txt
-        python -m pytest test_fuwarp_integration.py -v
+        python -m pytest test_fumitm_integration.py -v
 ```
 
 ## Maintenance
@@ -211,7 +211,7 @@ uv pip install --upgrade pytest pytest-mock
 uv pip freeze > requirements.txt
 ```
 
-### When fuwarp.py Changes
+### When fumitm.py Changes
 
 1. Run existing tests to detect regressions
 2. Update mock data if command outputs change
@@ -226,7 +226,7 @@ uv pip freeze > requirements.txt
 - Check Python version compatibility
 
 **Mock Failures**
-- Verify patch paths match imports in fuwarp.py
+- Verify patch paths match imports in fumitm.py
 - Check mock_data.py for correct response formats
 - Ensure MockBuilder configuration matches test requirements
 

--- a/test_suite/conftest.py
+++ b/test_suite/conftest.py
@@ -1,5 +1,5 @@
 """
-Pytest configuration for fuwarp integration tests.
+Pytest configuration for fumitm integration tests.
 
 This module provides shared fixtures and configuration for all tests.
 """
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 from unittest.mock import MagicMock, patch
 
-# Add parent directory to path so we can import fuwarp.py
+# Add parent directory to path so we can import fumitm.py
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Import mock data

--- a/test_suite/helpers.py
+++ b/test_suite/helpers.py
@@ -1,5 +1,5 @@
 """
-Test helpers and utilities for fuwarp tests.
+Test helpers and utilities for fumitm tests.
 
 This module provides helper classes and functions to simplify test setup and assertions.
 """
@@ -108,15 +108,15 @@ class MockBuilder:
 
 
 @contextmanager
-def mock_fuwarp_environment(mock_config):
-    """Context manager to set up a complete mock environment for fuwarp."""
+def mock_fumitm_environment(mock_config):
+    """Context manager to set up a complete mock environment for fumitm."""
     with patch('platform.system', return_value=mock_config['platform']), \
-         patch('fuwarp.shutil.which') as mock_which, \
-         patch('fuwarp.os.path.exists') as mock_exists, \
-         patch('fuwarp.subprocess.run') as mock_subprocess, \
-         patch('fuwarp.os.environ', mock_config['environ']), \
-         patch('fuwarp.os.makedirs'), \
-         patch('fuwarp.shutil.copy'), \
+         patch('fumitm.shutil.which') as mock_which, \
+         patch('fumitm.os.path.exists') as mock_exists, \
+         patch('fumitm.subprocess.run') as mock_subprocess, \
+         patch('fumitm.os.environ', mock_config['environ']), \
+         patch('fumitm.os.makedirs'), \
+         patch('fumitm.shutil.copy'), \
          patch('builtins.open', side_effect=mock_config['open_side_effect']):
         
         mock_which.side_effect = mock_config['which_side_effect']
@@ -175,35 +175,35 @@ def create_temp_cert_file(tmp_path):
     return str(cert_path)
 
 
-class FuwarpTestCase:
+class FumitmTestCase:
     """Base class providing common test functionality."""
 
     @staticmethod
-    def create_fuwarp_instance(mode='status', debug=False, selected_tools=None):
-        """Create a FuwarpPython instance with proper mocking."""
-        import fuwarp
+    def create_fumitm_instance(mode='status', debug=False, selected_tools=None):
+        """Create a FumitmPython instance with proper mocking."""
+        import fumitm
         with patch('platform.system', return_value='Darwin'):
-            return fuwarp.FuwarpPython(
+            return fumitm.FumitmPython(
                 mode=mode,
                 debug=debug,
                 selected_tools=selected_tools or []
             )
 
 
-def import_fuwarp_windows():
-    """Import the Windows version of fuwarp.
+def import_fumitm_windows():
+    """Import the Windows version of fumitm.
 
-    Since fuwarp_windows.py is in the parent directory, we need to use
+    Since fumitm_windows.py is in the parent directory, we need to use
     importlib to load it as a module.
     """
     import importlib.util
     import os
 
-    # Get path to fuwarp_windows.py relative to test_suite directory
+    # Get path to fumitm_windows.py relative to test_suite directory
     test_suite_dir = os.path.dirname(os.path.abspath(__file__))
-    module_path = os.path.join(os.path.dirname(test_suite_dir), "fuwarp_windows.py")
+    module_path = os.path.join(os.path.dirname(test_suite_dir), "fumitm_windows.py")
 
-    spec = importlib.util.spec_from_file_location("fuwarp_windows", module_path)
+    spec = importlib.util.spec_from_file_location("fumitm_windows", module_path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module

--- a/test_suite/mock_data.py
+++ b/test_suite/mock_data.py
@@ -1,5 +1,5 @@
 """
-Centralized mock data for fuwarp tests.
+Centralized mock data for fumitm tests.
 
 This module contains all mock responses and test data used across the test suite.
 """

--- a/test_suite/test_fumitm_integration.py
+++ b/test_suite/test_fumitm_integration.py
@@ -1,7 +1,7 @@
 """
-Integration tests for fuwarp.py
+Integration tests for fumitm.py
 
-These tests verify the core workflows and functionality of the fuwarp script
+These tests verify the core workflows and functionality of the fumitm script
 by mocking external dependencies and testing realistic scenarios.
 """
 import os
@@ -12,16 +12,16 @@ import pytest
 
 # Import test utilities
 from helpers import (
-    MockBuilder, mock_fuwarp_environment, assert_subprocess_called_with,
-    assert_file_written, FuwarpTestCase
+    MockBuilder, mock_fumitm_environment, assert_subprocess_called_with,
+    assert_file_written, FumitmTestCase
 )
 import mock_data
 
-# Import the fuwarp module
-import fuwarp
+# Import the fumitm module
+import fumitm
 
 
-class TestCertificateManagement(FuwarpTestCase):
+class TestCertificateManagement(FumitmTestCase):
     """Tests for certificate download and validation."""
     
     def test_certificate_download_success(self):
@@ -31,8 +31,8 @@ class TestCertificateManagement(FuwarpTestCase):
             .with_tools('openssl')
             .build())
         
-        with mock_fuwarp_environment(mock_config) as mocks:
-            instance = self.create_fuwarp_instance(mode='install')
+        with mock_fumitm_environment(mock_config) as mocks:
+            instance = self.create_fumitm_instance(mode='install')
             result = instance.download_certificate()
             
             assert result is True
@@ -42,8 +42,8 @@ class TestCertificateManagement(FuwarpTestCase):
         """Test certificate download when WARP is not installed."""
         mock_config = MockBuilder().with_warp_not_installed().build()
         
-        with mock_fuwarp_environment(mock_config):
-            instance = self.create_fuwarp_instance(mode='install')
+        with mock_fumitm_environment(mock_config):
+            instance = self.create_fumitm_instance(mode='install')
             result = instance.download_certificate()
             
             assert result is False
@@ -56,8 +56,8 @@ class TestCertificateManagement(FuwarpTestCase):
             .with_subprocess_response(returncode=0)  # openssl verify success
             .build())
         
-        with mock_fuwarp_environment(mock_config) as mocks:
-            instance = self.create_fuwarp_instance()
+        with mock_fumitm_environment(mock_config) as mocks:
+            instance = self.create_fumitm_instance()
             # Trigger certificate validation through status check
             instance.check_all_status()
             
@@ -73,15 +73,15 @@ class TestCertificateManagement(FuwarpTestCase):
             .with_subprocess_response(returncode=0)  # openssl check shows valid
             .build())
         
-        with mock_fuwarp_environment(mock_config) as mocks:
-            instance = self.create_fuwarp_instance()
+        with mock_fumitm_environment(mock_config) as mocks:
+            instance = self.create_fumitm_instance()
             instance.check_all_status()
             
             # Should check existing certificate validity
             assert mocks['exists'].called
 
 
-class TestToolSetup(FuwarpTestCase):
+class TestToolSetup(FumitmTestCase):
     """Tests for individual tool certificate setup."""
     
     @pytest.mark.parametrize("tool,check_commands", [
@@ -100,8 +100,8 @@ class TestToolSetup(FuwarpTestCase):
         for _ in check_commands:
             mock_config['subprocess_side_effect'].append(MagicMock(returncode=0, stdout=""))
         
-        with mock_fuwarp_environment(mock_config) as mocks:
-            instance = self.create_fuwarp_instance()
+        with mock_fumitm_environment(mock_config) as mocks:
+            instance = self.create_fumitm_instance()
             setup_method = getattr(instance, f"setup_{tool}_cert")
             setup_method()
             
@@ -118,11 +118,11 @@ class TestToolSetup(FuwarpTestCase):
             .with_subprocess_response(returncode=0)  # npm config set
             .build())
         
-        with mock_fuwarp_environment(mock_config) as mocks:
+        with mock_fumitm_environment(mock_config) as mocks:
             # Mock input to auto-answer 'Y' and Path.touch
             with patch('builtins.input', return_value='Y'), \
                  patch('pathlib.Path.touch'):
-                instance = self.create_fuwarp_instance(mode='install')
+                instance = self.create_fumitm_instance(mode='install')
                 instance.setup_node_cert()
             
             # Should check npm config
@@ -137,8 +137,8 @@ class TestToolSetup(FuwarpTestCase):
             .with_subprocess_response(returncode=1)  # pip not found
             .build())
         
-        with mock_fuwarp_environment(mock_config) as mocks:
-            instance = self.create_fuwarp_instance(mode='status')
+        with mock_fumitm_environment(mock_config) as mocks:
+            instance = self.create_fumitm_instance(mode='status')
             instance.setup_python_cert()
             
             # Python should have been checked
@@ -146,7 +146,7 @@ class TestToolSetup(FuwarpTestCase):
             assert any(call('python3') in mocks['which'].call_args_list for call in [call])
 
 
-class TestJavaMultiInstallation(FuwarpTestCase):
+class TestJavaMultiInstallation(FumitmTestCase):
     """Tests for multi-Java installation detection and configuration."""
 
     def test_find_all_java_homes_macos_multiple_installations(self):
@@ -181,7 +181,7 @@ class TestJavaMultiInstallation(FuwarpTestCase):
             mock_result.stdout = java_home_output
             mock_run.return_value = mock_result
 
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
             java_homes = instance.find_all_java_homes()
 
             assert len(java_homes) == 3
@@ -211,7 +211,7 @@ class TestJavaMultiInstallation(FuwarpTestCase):
 
             mock_listdir.side_effect = listdir_side_effect
 
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
             java_homes = instance.find_all_java_homes()
 
             # Should find the .jdk directories
@@ -236,7 +236,7 @@ class TestJavaMultiInstallation(FuwarpTestCase):
             mock_result.stdout = alternatives_output
             mock_run.return_value = mock_result
 
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
             java_homes = instance.find_all_java_homes()
 
             assert len(java_homes) >= 3
@@ -252,7 +252,7 @@ class TestJavaMultiInstallation(FuwarpTestCase):
         ]
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='install')
+            instance = fumitm.FumitmPython(mode='install')
 
             with patch.object(instance, 'command_exists', return_value=True), \
                  patch.object(instance, 'find_all_java_homes', return_value=fake_java_homes), \
@@ -278,7 +278,7 @@ class TestJavaMultiInstallation(FuwarpTestCase):
         ]
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
             with patch.object(instance, 'command_exists', return_value=True), \
                  patch.object(instance, 'find_all_java_homes', return_value=fake_java_homes), \
@@ -316,7 +316,7 @@ class TestJavaMultiInstallation(FuwarpTestCase):
             mock_result.stdout = ""
             mock_run.return_value = mock_result
 
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
             # Mock find_java_home to return a path but find_java_cacerts returns empty
             with patch.object(instance, 'find_java_home', return_value='/fake/java'), \
@@ -328,35 +328,35 @@ class TestJavaMultiInstallation(FuwarpTestCase):
                 assert len(java_homes) == 0
 
 
-class TestCLIAndWorkflow(FuwarpTestCase):
+class TestCLIAndWorkflow(FumitmTestCase):
     """Tests for CLI argument parsing and complete workflows."""
     
-    @patch('fuwarp.sys.argv', ['fuwarp.py', '--fix'])
+    @patch('fumitm.sys.argv', ['fumitm.py', '--fix'])
     def test_cli_fix_mode(self):
         """Test --fix argument sets install mode."""
-        with patch('fuwarp.FuwarpPython') as mock_class:
+        with patch('fumitm.FumitmPython') as mock_class:
             mock_instance = MagicMock()
             mock_instance.main.return_value = 0
             mock_class.return_value = mock_instance
             
-            with patch('fuwarp.sys.exit'):
-                fuwarp.main()
+            with patch('fumitm.sys.exit'):
+                fumitm.main()
             
             mock_class.assert_called_with(
                 mode='install', debug=False, selected_tools=[],
                 cert_file=None, manual_cert=False, skip_verify=False
             )
     
-    @patch('fuwarp.sys.argv', ['fuwarp.py', '--tools', 'node,python'])
+    @patch('fumitm.sys.argv', ['fumitm.py', '--tools', 'node,python'])
     def test_cli_tool_selection(self):
         """Test --tools argument parsing."""
-        with patch('fuwarp.FuwarpPython') as mock_class:
+        with patch('fumitm.FumitmPython') as mock_class:
             mock_instance = MagicMock()
             mock_instance.main.return_value = 0
             mock_class.return_value = mock_instance
             
-            with patch('fuwarp.sys.exit'):
-                fuwarp.main()
+            with patch('fumitm.sys.exit'):
+                fumitm.main()
             
             mock_class.assert_called_with(
                 mode='status',
@@ -379,8 +379,8 @@ class TestCLIAndWorkflow(FuwarpTestCase):
             .with_subprocess_response(returncode=0)  # openssl validity check
             .build())
         
-        with mock_fuwarp_environment(mock_config) as mocks:
-            instance = self.create_fuwarp_instance()
+        with mock_fumitm_environment(mock_config) as mocks:
+            instance = self.create_fumitm_instance()
             # Run the complete status check
             instance.check_all_status()
             
@@ -392,12 +392,12 @@ class TestCLIAndWorkflow(FuwarpTestCase):
             assert any(call('keytool') in mocks['which'].call_args_list for call in [call])
 
 
-class TestToolSelection(FuwarpTestCase):
+class TestToolSelection(FumitmTestCase):
     """Tests for tool selection and filtering logic."""
     
     def test_tool_selection_by_key(self):
         """Test selecting tools by their key names."""
-        instance = self.create_fuwarp_instance(selected_tools=['node', 'python'])
+        instance = self.create_fumitm_instance(selected_tools=['node', 'python'])
         
         assert instance.should_process_tool('node') is True
         assert instance.should_process_tool('python') is True
@@ -405,7 +405,7 @@ class TestToolSelection(FuwarpTestCase):
     
     def test_tool_selection_by_tag(self):
         """Test selecting tools by their tags."""
-        instance = self.create_fuwarp_instance(selected_tools=['nodejs', 'pip'])
+        instance = self.create_fumitm_instance(selected_tools=['nodejs', 'pip'])
         
         # Should match by tag
         assert instance.should_process_tool('node') is True  # 'nodejs' tag
@@ -414,7 +414,7 @@ class TestToolSelection(FuwarpTestCase):
     
     def test_tool_selection_validation(self):
         """Test validation of selected tools."""
-        instance = self.create_fuwarp_instance(
+        instance = self.create_fumitm_instance(
             selected_tools=['node', 'invalid-tool', 'python']
         )
         
@@ -423,7 +423,7 @@ class TestToolSelection(FuwarpTestCase):
         assert 'node' not in invalid_tools
 
 
-class TestErrorScenarios(FuwarpTestCase):
+class TestErrorScenarios(FumitmTestCase):
     """Tests for error handling and edge cases."""
     
     def test_certificate_download_network_error(self):
@@ -436,8 +436,8 @@ class TestErrorScenarios(FuwarpTestCase):
             )
             .build())
         
-        with mock_fuwarp_environment(mock_config):
-            instance = self.create_fuwarp_instance(mode='install')
+        with mock_fumitm_environment(mock_config):
+            instance = self.create_fumitm_instance(mode='install')
             result = instance.download_certificate()
             
             assert result is False
@@ -449,11 +449,11 @@ class TestErrorScenarios(FuwarpTestCase):
             .with_tools('openssl')
             .build())
         
-        with mock_fuwarp_environment(mock_config):
-            with patch('fuwarp.shutil.copy') as mock_copy:
+        with mock_fumitm_environment(mock_config):
+            with patch('fumitm.shutil.copy') as mock_copy:
                 mock_copy.side_effect = PermissionError(mock_data.PERMISSION_DENIED_ERROR)
                 
-                instance = self.create_fuwarp_instance(mode='install')
+                instance = self.create_fumitm_instance(mode='install')
                 # The download_certificate method doesn't catch PermissionError
                 # so we expect it to raise
                 with pytest.raises(PermissionError):
@@ -473,8 +473,8 @@ class TestErrorScenarios(FuwarpTestCase):
             )
             .build())
         
-        with mock_fuwarp_environment(mock_config):
-            instance = self.create_fuwarp_instance(mode='install')
+        with mock_fumitm_environment(mock_config):
+            instance = self.create_fumitm_instance(mode='install')
             result = instance.download_certificate()
             
             assert result is False
@@ -486,8 +486,8 @@ class TestErrorScenarios(FuwarpTestCase):
             .with_certificate()
             .build())  # No tools configured except warp
         
-        with mock_fuwarp_environment(mock_config) as mocks:
-            instance = self.create_fuwarp_instance(mode='status')
+        with mock_fumitm_environment(mock_config) as mocks:
+            instance = self.create_fumitm_instance(mode='status')
             # Run status check - should handle missing tools gracefully
             instance.check_all_status()
             
@@ -497,17 +497,17 @@ class TestErrorScenarios(FuwarpTestCase):
             assert True  # If we get here, no exceptions were raised
 
 
-class TestConnectionVerification(FuwarpTestCase):
+class TestConnectionVerification(FumitmTestCase):
     """Tests for network connection verification."""
     
-    @patch('fuwarp.urllib.request.urlopen')
+    @patch('fumitm.urllib.request.urlopen')
     def test_python_connection_verification_success(self, mock_urlopen):
         """Test successful Python HTTPS connection verification."""
         mock_response = MagicMock()
         mock_response.code = 200
         mock_urlopen.return_value.__enter__.return_value = mock_response
         
-        instance = self.create_fuwarp_instance()
+        instance = self.create_fumitm_instance()
         result = instance.verify_connection('python')
         
         assert result == "WORKING"
@@ -523,8 +523,8 @@ class TestConnectionVerification(FuwarpTestCase):
             )
             .build())
         
-        with mock_fuwarp_environment(mock_config):
-            instance = self.create_fuwarp_instance()
+        with mock_fumitm_environment(mock_config):
+            instance = self.create_fumitm_instance()
             result = instance.verify_connection('node')
             
             assert result == "WORKING"
@@ -539,14 +539,14 @@ class TestConnectionVerification(FuwarpTestCase):
             )
             .build())
         
-        with mock_fuwarp_environment(mock_config):
-            instance = self.create_fuwarp_instance()
+        with mock_fumitm_environment(mock_config):
+            instance = self.create_fumitm_instance()
             result = instance.verify_connection('wget')
             
             assert result == "FAILED"
 
 
-class TestPlatformSpecific(FuwarpTestCase):
+class TestPlatformSpecific(FumitmTestCase):
     """Tests for platform-specific behavior."""
 
     @pytest.mark.parametrize("platform,expected_path", [
@@ -556,14 +556,14 @@ class TestPlatformSpecific(FuwarpTestCase):
     def test_platform_specific_paths(self, platform, expected_path):
         """Test that platform-specific paths are used correctly."""
         with patch('platform.system', return_value=platform):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
             # Check that instance is aware of platform
             # This would need actual implementation testing
             assert True  # Placeholder for actual platform-specific tests
 
 
-class TestStatusFunctionContracts(FuwarpTestCase):
+class TestStatusFunctionContracts(FumitmTestCase):
     """Contract tests for all check_*_status() functions.
 
     These tests verify that all status check functions return a boolean value,
@@ -594,7 +594,7 @@ class TestStatusFunctionContracts(FuwarpTestCase):
         cert_file.write_text(mock_data.MOCK_CERTIFICATE)
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         status_methods = self.get_all_status_methods(instance)
 
@@ -638,7 +638,7 @@ class TestStatusFunctionContracts(FuwarpTestCase):
         cert_file.write_text(mock_data.MOCK_CERTIFICATE)
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         status_methods = self.get_all_status_methods(instance)
 
@@ -666,7 +666,7 @@ class TestStatusFunctionContracts(FuwarpTestCase):
         cert_file.write_text(mock_data.MOCK_CERTIFICATE)
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         # Mock jenv having Java installations
         fake_java_homes = ['/fake/java/home/17', '/fake/java/home/11']
@@ -687,7 +687,7 @@ class TestStatusFunctionContracts(FuwarpTestCase):
             assert isinstance(result, bool), f"check_jenv_status returned {type(result).__name__}, not bool"
 
 
-class TestBundleCreation(FuwarpTestCase):
+class TestBundleCreation(FumitmTestCase):
     """Tests for system CA bundle creation helper."""
 
     def test_creates_bundle_from_macos_system_certs(self, tmp_path):
@@ -699,7 +699,7 @@ class TestBundleCreation(FuwarpTestCase):
         target_bundle = tmp_path / "bundle.pem"
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='install')
+            instance = fumitm.FumitmPython(mode='install')
 
             # Mock os.path.exists to simulate macOS system cert location
             with patch('os.path.exists') as mock_exists:
@@ -717,7 +717,7 @@ class TestBundleCreation(FuwarpTestCase):
         target_bundle = tmp_path / "bundle.pem"
 
         with patch('platform.system', return_value='Linux'):
-            instance = fuwarp.FuwarpPython(mode='install')
+            instance = fumitm.FumitmPython(mode='install')
 
             # Mock os.path.exists: macOS path doesn't exist, Linux path does
             with patch('os.path.exists') as mock_exists:
@@ -735,7 +735,7 @@ class TestBundleCreation(FuwarpTestCase):
         target_bundle = tmp_path / "bundle.pem"
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='install')
+            instance = fumitm.FumitmPython(mode='install')
 
             # Mock os.path.exists: neither system cert location exists
             with patch('os.path.exists', return_value=False):
@@ -751,7 +751,7 @@ class TestBundleCreation(FuwarpTestCase):
         target_bundle = tmp_path / "bundle.pem"
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='install')
+            instance = fumitm.FumitmPython(mode='install')
 
             # Test True case (system certs exist)
             with patch('os.path.exists', side_effect=lambda p: p == "/etc/ssl/cert.pem"):
@@ -765,7 +765,7 @@ class TestBundleCreation(FuwarpTestCase):
                 assert result is False
 
 
-class TestCertificateAppending(FuwarpTestCase):
+class TestCertificateAppending(FumitmTestCase):
     """Tests for certificate appending to ensure proper PEM formatting (issue #13)."""
 
     def test_append_to_bundle_without_trailing_newline(self, tmp_path):
@@ -785,7 +785,7 @@ class TestCertificateAppending(FuwarpTestCase):
 
         # Create instance and call safe_append_certificate
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='install')
+            instance = fumitm.FumitmPython(mode='install')
             result = instance.safe_append_certificate(str(cert_file), str(bundle_file))
 
         assert result is True
@@ -813,7 +813,7 @@ class TestCertificateAppending(FuwarpTestCase):
 
         # Create instance and call safe_append_certificate
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='install')
+            instance = fumitm.FumitmPython(mode='install')
             result = instance.safe_append_certificate(str(cert_file), str(bundle_file))
 
         assert result is True
@@ -836,7 +836,7 @@ class TestCertificateAppending(FuwarpTestCase):
 
         # Create instance and call safe_append_certificate
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='install')
+            instance = fumitm.FumitmPython(mode='install')
             result = instance.safe_append_certificate(str(cert_file), str(bundle_file))
 
         assert result is True
@@ -862,7 +862,7 @@ class TestCertificateAppending(FuwarpTestCase):
         # Create instance and mock certificate_exists_in_file to return True
         # (since mock certificates don't work with openssl fingerprint check)
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='install')
+            instance = fumitm.FumitmPython(mode='install')
             with patch.object(instance, 'certificate_exists_in_file', return_value=True):
                 result = instance.safe_append_certificate(str(cert_file), str(bundle_file))
 
@@ -883,7 +883,7 @@ class TestCertificateAppending(FuwarpTestCase):
 
         # Create instance and call safe_append_certificate
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='install')
+            instance = fumitm.FumitmPython(mode='install')
             result = instance.safe_append_certificate(str(cert_file), str(bundle_file))
 
         assert result is True
@@ -900,8 +900,8 @@ class TestCertificateAppending(FuwarpTestCase):
 class TestCodeQuality:
     """Static analysis tests to catch unsafe patterns in the codebase."""
 
-    def test_no_unsafe_certificate_appends_in_fuwarp(self):
-        """Ensure fuwarp.py uses safe_append_certificate() for all certificate appends.
+    def test_no_unsafe_certificate_appends_in_fumitm(self):
+        """Ensure fumitm.py uses safe_append_certificate() for all certificate appends.
 
         Regression test for issue #21 - prevents adding new unsafe certificate
         appends that could produce malformed PEM files.
@@ -915,9 +915,9 @@ class TestCodeQuality:
 
         # Read the source file
         test_dir = os.path.dirname(os.path.abspath(__file__))
-        fuwarp_path = os.path.join(os.path.dirname(test_dir), "fuwarp.py")
+        fumitm_path = os.path.join(os.path.dirname(test_dir), "fumitm.py")
 
-        with open(fuwarp_path, 'r') as f:
+        with open(fumitm_path, 'r') as f:
             source = f.read()
 
         # Pattern 1: Direct append mode opens for bundle/cert files
@@ -929,7 +929,7 @@ class TestCodeQuality:
 
         matches = unsafe_append_pattern.findall(source)
         assert not matches, (
-            f"Found unsafe certificate append patterns in fuwarp.py:\n"
+            f"Found unsafe certificate append patterns in fumitm.py:\n"
             f"{matches}\n\n"
             f"Use self.safe_append_certificate(cert_path, target_path) instead"
         )
@@ -942,24 +942,24 @@ class TestCodeQuality:
 
         matches = unsafe_write_pattern.findall(source)
         assert not matches, (
-            f"Found unsafe certificate write patterns in fuwarp.py:\n"
+            f"Found unsafe certificate write patterns in fumitm.py:\n"
             f"{matches}\n\n"
             f"Use self.safe_append_certificate(cert_path, target_path) instead"
         )
 
-    def test_no_unsafe_certificate_appends_in_fuwarp_windows(self):
-        """Ensure fuwarp_windows.py uses append_certificate_if_missing() for all appends.
+    def test_no_unsafe_certificate_appends_in_fumitm_windows(self):
+        """Ensure fumitm_windows.py uses append_certificate_if_missing() for all appends.
 
-        Same as test_no_unsafe_certificate_appends_in_fuwarp but for Windows port.
+        Same as test_no_unsafe_certificate_appends_in_fumitm but for Windows port.
         """
         import os
         import re
 
         # Read the source file
         test_dir = os.path.dirname(os.path.abspath(__file__))
-        fuwarp_windows_path = os.path.join(os.path.dirname(test_dir), "fuwarp_windows.py")
+        fumitm_windows_path = os.path.join(os.path.dirname(test_dir), "fumitm_windows.py")
 
-        with open(fuwarp_windows_path, 'r') as f:
+        with open(fumitm_windows_path, 'r') as f:
             source = f.read()
 
         # Pattern 1: Direct append mode opens for bundle/cert files
@@ -985,13 +985,13 @@ class TestCodeQuality:
                     unsafe_lines.append(f"Line {i}: {line.strip()}")
 
         assert not unsafe_lines, (
-            f"Found unsafe certificate append patterns in fuwarp_windows.py:\n"
+            f"Found unsafe certificate append patterns in fumitm_windows.py:\n"
             + "\n".join(unsafe_lines) + "\n\n"
             f"Use self.append_certificate_if_missing(cert_path, target_path) instead"
         )
 
-    def test_no_unused_globals_in_fuwarp(self):
-        """Ensure no unused global variables exist in fuwarp.py.
+    def test_no_unused_globals_in_fumitm(self):
+        """Ensure no unused global variables exist in fumitm.py.
 
         Regression test to prevent unused globals like SHELL_MODIFIED and
         CERT_FINGERPRINT from being introduced (or reintroduced).
@@ -1000,9 +1000,9 @@ class TestCodeQuality:
         import re
 
         test_dir = os.path.dirname(os.path.abspath(__file__))
-        fuwarp_path = os.path.join(os.path.dirname(test_dir), "fuwarp.py")
+        fumitm_path = os.path.join(os.path.dirname(test_dir), "fumitm.py")
 
-        with open(fuwarp_path, 'r') as f:
+        with open(fumitm_path, 'r') as f:
             source = f.read()
 
         # Find module-level UPPER_CASE variable assignments (globals)
@@ -1027,22 +1027,22 @@ class TestCodeQuality:
                 unused_globals.append(name)
 
         assert not unused_globals, (
-            f"Unused global variables found in fuwarp.py: {unused_globals}\n"
+            f"Unused global variables found in fumitm.py: {unused_globals}\n"
             "These variables are defined but never referenced elsewhere in the code."
         )
 
-    def test_no_unused_globals_in_fuwarp_windows(self):
-        """Ensure no unused global variables exist in fuwarp_windows.py.
+    def test_no_unused_globals_in_fumitm_windows(self):
+        """Ensure no unused global variables exist in fumitm_windows.py.
 
-        Same check as test_no_unused_globals_in_fuwarp but for Windows port.
+        Same check as test_no_unused_globals_in_fumitm but for Windows port.
         """
         import os
         import re
 
         test_dir = os.path.dirname(os.path.abspath(__file__))
-        fuwarp_windows_path = os.path.join(os.path.dirname(test_dir), "fuwarp_windows.py")
+        fumitm_windows_path = os.path.join(os.path.dirname(test_dir), "fumitm_windows.py")
 
-        with open(fuwarp_windows_path, 'r') as f:
+        with open(fumitm_windows_path, 'r') as f:
             source = f.read()
 
         # Known unused globals pending Windows refactoring
@@ -1071,11 +1071,11 @@ class TestCodeQuality:
                 unused_globals.append(name)
 
         assert not unused_globals, (
-            f"Unused global variables found in fuwarp_windows.py: {unused_globals}\n"
+            f"Unused global variables found in fumitm_windows.py: {unused_globals}\n"
             "These variables are defined but never referenced elsewhere in the code."
         )
 
-    def test_consistent_setup_messaging_in_fuwarp(self):
+    def test_consistent_setup_messaging_in_fumitm(self):
         """Ensure setup functions use consistent messaging patterns.
 
         All setup functions should use "Configuring <tool> certificate..."
@@ -1086,9 +1086,9 @@ class TestCodeQuality:
         import re
 
         test_dir = os.path.dirname(os.path.abspath(__file__))
-        fuwarp_path = os.path.join(os.path.dirname(test_dir), "fuwarp.py")
+        fumitm_path = os.path.join(os.path.dirname(test_dir), "fumitm.py")
 
-        with open(fuwarp_path, 'r') as f:
+        with open(fumitm_path, 'r') as f:
             source = f.read()
 
         # Find "Setting up" patterns which should be "Configuring"
@@ -1096,13 +1096,13 @@ class TestCodeQuality:
 
         matches = setting_up_pattern.findall(source)
         assert not matches, (
-            f"Found inconsistent messaging in fuwarp.py:\n"
+            f"Found inconsistent messaging in fumitm.py:\n"
             f"{matches}\n\n"
             f"Use 'Configuring <tool> certificate...' instead of 'Setting up <tool> certificate...'"
         )
 
-    def test_no_bare_except_clauses_in_fuwarp(self):
-        """Ensure no bare 'except:' clauses exist in fuwarp.py.
+    def test_no_bare_except_clauses_in_fumitm(self):
+        """Ensure no bare 'except:' clauses exist in fumitm.py.
 
         Bare except clauses catch all exceptions including SystemExit and
         KeyboardInterrupt, which is rarely what's intended. They should be
@@ -1113,9 +1113,9 @@ class TestCodeQuality:
         import re
 
         test_dir = os.path.dirname(os.path.abspath(__file__))
-        fuwarp_path = os.path.join(os.path.dirname(test_dir), "fuwarp.py")
+        fumitm_path = os.path.join(os.path.dirname(test_dir), "fumitm.py")
 
-        with open(fuwarp_path, 'r') as f:
+        with open(fumitm_path, 'r') as f:
             lines = f.readlines()
 
         # Find bare except clauses (except: without an exception type)
@@ -1126,12 +1126,12 @@ class TestCodeQuality:
                 bare_excepts.append(f"Line {i}: {line.strip()}")
 
         assert not bare_excepts, (
-            f"Found bare 'except:' clauses in fuwarp.py:\n"
+            f"Found bare 'except:' clauses in fumitm.py:\n"
             + "\n".join(bare_excepts) + "\n\n"
             f"Replace with 'except Exception:' or a more specific exception type."
         )
 
-    def test_no_raw_cert_comparisons_in_fuwarp(self):
+    def test_no_raw_cert_comparisons_in_fumitm(self):
         """Ensure setup functions use certificate_exists_in_file() not raw string comparison.
 
         Regression test for issue #35 - Status checks use certificate_exists_in_file()
@@ -1149,9 +1149,9 @@ class TestCodeQuality:
         import re
 
         test_dir = os.path.dirname(os.path.abspath(__file__))
-        fuwarp_path = os.path.join(os.path.dirname(test_dir), "fuwarp.py")
+        fumitm_path = os.path.join(os.path.dirname(test_dir), "fumitm.py")
 
-        with open(fuwarp_path, 'r') as f:
+        with open(fumitm_path, 'r') as f:
             source = f.read()
 
         # Find raw certificate content comparisons in setup functions
@@ -1171,7 +1171,7 @@ class TestCodeQuality:
                     violations.append(f"Line {i}: {line.strip()} ({description})")
 
         assert not violations, (
-            f"Found raw certificate comparisons in fuwarp.py:\n"
+            f"Found raw certificate comparisons in fumitm.py:\n"
             + "\n".join(violations) + "\n\n"
             "Setup functions must use self.certificate_exists_in_file(CERT_PATH, target)\n"
             "instead of raw 'cert_content in file_content' comparisons.\n"
@@ -1179,7 +1179,7 @@ class TestCodeQuality:
         )
 
 
-class TestPerformance(FuwarpTestCase):
+class TestPerformance(FumitmTestCase):
     """Tests for performance and subprocess call limits.
 
     These tests ensure that certificate checking operations don't spawn
@@ -1202,7 +1202,7 @@ class TestPerformance(FuwarpTestCase):
         bundle_file.write_text(mock_data.SAMPLE_CA_BUNDLE + mock_data.MOCK_CERTIFICATE)
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         # Count subprocess calls
         with patch('subprocess.run') as mock_subprocess:
@@ -1229,7 +1229,7 @@ class TestPerformance(FuwarpTestCase):
         bundle_file.write_text(mock_data.SAMPLE_CA_BUNDLE)
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         with patch('subprocess.run') as mock_subprocess:
             result = instance.certificate_likely_exists_in_file(
@@ -1259,7 +1259,7 @@ class TestPerformance(FuwarpTestCase):
         bundle_file.write_text(mock_data.SAMPLE_CA_BUNDLE + mock_data.MOCK_CERTIFICATE)
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='install')
+            instance = fumitm.FumitmPython(mode='install')
 
         with patch('subprocess.run') as mock_subprocess:
             # This should detect the certificate already exists and skip
@@ -1301,7 +1301,7 @@ class TestPerformance(FuwarpTestCase):
         bundle_file.write_text(bundle_content)
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='install')
+            instance = fumitm.FumitmPython(mode='install')
 
         with patch('subprocess.run') as mock_subprocess:
             # Check if certificate exists in bundle
@@ -1323,10 +1323,10 @@ class TestPerformance(FuwarpTestCase):
         cert_file.write_text(mock_data.MOCK_CERTIFICATE)
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='install')
+            instance = fumitm.FumitmPython(mode='install')
 
         # Mock the CERT_PATH to our test file
-        with patch.object(fuwarp, 'CERT_PATH', str(cert_file)):
+        with patch.object(fumitm, 'CERT_PATH', str(cert_file)):
             with patch('subprocess.run') as mock_subprocess:
                 mock_subprocess.return_value = MagicMock(
                     returncode=0,
@@ -1347,7 +1347,7 @@ class TestPerformance(FuwarpTestCase):
                 )
 
 
-class TestCertificateContentMatching(FuwarpTestCase):
+class TestCertificateContentMatching(FumitmTestCase):
     """Tests for pure Python certificate content matching.
 
     These tests verify that certificate duplicate detection works correctly
@@ -1360,7 +1360,7 @@ class TestCertificateContentMatching(FuwarpTestCase):
         cert_file.write_text(mock_data.MOCK_CERTIFICATE)
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         # The function should be able to extract a unique portion
         # This tests the internal helper if it exists
@@ -1379,7 +1379,7 @@ class TestCertificateContentMatching(FuwarpTestCase):
         bundle_file.write_text(mock_data.SAMPLE_CA_BUNDLE + "\n" + mock_data.MOCK_CERTIFICATE)
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         result = instance.certificate_likely_exists_in_file(
             str(cert_file), str(bundle_file)
@@ -1397,7 +1397,7 @@ class TestCertificateContentMatching(FuwarpTestCase):
         bundle_file.write_text(mock_data.SAMPLE_CA_BUNDLE)
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         result = instance.certificate_likely_exists_in_file(
             str(cert_file), str(bundle_file)
@@ -1416,7 +1416,7 @@ class TestCertificateContentMatching(FuwarpTestCase):
         bundle_file.write_text(mock_data.SAMPLE_CA_BUNDLE + "\n\n\n" + cert_with_spaces)
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         result = instance.certificate_likely_exists_in_file(
             str(cert_file), str(bundle_file)
@@ -1426,13 +1426,13 @@ class TestCertificateContentMatching(FuwarpTestCase):
         assert result is True, "Failed to find certificate with whitespace variations"
 
 
-class TestUpdateCheck(FuwarpTestCase):
+class TestUpdateCheck(FumitmTestCase):
     """Tests for the update check functionality."""
 
     def test_check_for_updates_uses_unverified_ssl(self, tmp_path):
         """Verify update check uses unverified SSL context."""
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         with patch('urllib.request.urlopen') as mock_urlopen, \
              patch('builtins.open', mock_open(read_data=b'test content')):
@@ -1454,7 +1454,7 @@ class TestUpdateCheck(FuwarpTestCase):
     def test_check_for_updates_handles_network_error(self, tmp_path):
         """Verify update check handles network errors gracefully."""
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         with patch('urllib.request.urlopen') as mock_urlopen:
             mock_urlopen.side_effect = urllib.error.URLError("Network error")
@@ -1465,13 +1465,13 @@ class TestUpdateCheck(FuwarpTestCase):
             assert result is False
 
 
-class TestGcloudVerification(FuwarpTestCase):
+class TestGcloudVerification(FumitmTestCase):
     """Tests for gcloud verification functionality."""
 
     def test_verify_connection_gcloud_working(self, tmp_path):
         """Test gcloud verification when API call succeeds."""
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         with patch('subprocess.run') as mock_run, \
              patch.object(instance, 'command_exists', return_value=True), \
@@ -1491,7 +1491,7 @@ class TestGcloudVerification(FuwarpTestCase):
     def test_verify_connection_gcloud_ssl_error(self, tmp_path):
         """Test gcloud verification with SSL error."""
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         with patch('subprocess.run') as mock_run, \
              patch.object(instance, 'command_exists', return_value=True), \
@@ -1510,7 +1510,7 @@ class TestGcloudVerification(FuwarpTestCase):
     def test_verify_connection_gcloud_permission_error_is_ok(self, tmp_path):
         """Test gcloud verification with permission error (TLS still works)."""
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         with patch('subprocess.run') as mock_run, \
              patch.object(instance, 'command_exists', return_value=True), \
@@ -1531,7 +1531,7 @@ class TestGcloudVerification(FuwarpTestCase):
     def test_verify_connection_gcloud_not_installed(self, tmp_path):
         """Test gcloud verification when not installed."""
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         with patch.object(instance, 'command_exists', return_value=False):
             result = instance.verify_connection("gcloud")
@@ -1544,7 +1544,7 @@ class TestGcloudVerification(FuwarpTestCase):
         cert_file.write_text(mock_data.MOCK_CERTIFICATE)
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         with patch.object(instance, 'command_exists', return_value=True), \
              patch.object(instance, 'verify_connection', return_value="WORKING"), \
@@ -1568,7 +1568,7 @@ class TestGcloudVerification(FuwarpTestCase):
         cert_file.write_text(mock_data.MOCK_CERTIFICATE)
 
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         with patch.object(instance, 'command_exists', return_value=True), \
              patch.object(instance, 'verify_connection', return_value="FAILED"), \
@@ -1585,77 +1585,77 @@ class TestGcloudVerification(FuwarpTestCase):
             assert has_issues is True
 
 
-class TestCalVerVersion(FuwarpTestCase):
+class TestCalVerVersion(FumitmTestCase):
     """Tests for CalVer version handling."""
 
     def test_version_variable_exists(self):
         """Verify __version__ is defined."""
-        assert hasattr(fuwarp, '__version__')
-        assert fuwarp.__version__ is not None
+        assert hasattr(fumitm, '__version__')
+        assert fumitm.__version__ is not None
 
     def test_version_format_valid(self):
         """Verify version follows CalVer format."""
         import re
         pattern = r'^\d{4}\.\d{1,2}\.\d{1,2}(\.\d+)?$'
-        assert re.match(pattern, fuwarp.__version__), \
-            f"Version '{fuwarp.__version__}' doesn't match CalVer format YYYY.M.D or YYYY.M.D.N"
+        assert re.match(pattern, fumitm.__version__), \
+            f"Version '{fumitm.__version__}' doesn't match CalVer format YYYY.M.D or YYYY.M.D.N"
 
     def test_parse_calver_basic(self):
         """Test CalVer parsing for basic version."""
-        result = fuwarp.parse_calver("2025.12.18")
+        result = fumitm.parse_calver("2025.12.18")
         assert result == (2025, 12, 18, 0)
 
     def test_parse_calver_with_patch(self):
         """Test CalVer parsing with patch number."""
-        result = fuwarp.parse_calver("2025.12.18.3")
+        result = fumitm.parse_calver("2025.12.18.3")
         assert result == (2025, 12, 18, 3)
 
     def test_parse_calver_single_digit_month_day(self):
         """Test CalVer parsing with single-digit month/day."""
-        result = fuwarp.parse_calver("2025.1.5")
+        result = fumitm.parse_calver("2025.1.5")
         assert result == (2025, 1, 5, 0)
 
     def test_parse_calver_invalid_format(self):
         """Test CalVer parsing rejects invalid formats."""
         with pytest.raises(ValueError):
-            fuwarp.parse_calver("invalid")
+            fumitm.parse_calver("invalid")
         with pytest.raises(ValueError):
-            fuwarp.parse_calver("2025.12")
+            fumitm.parse_calver("2025.12")
         with pytest.raises(ValueError):
-            fuwarp.parse_calver("2025")
+            fumitm.parse_calver("2025")
 
     def test_version_comparison_newer(self):
         """Test version comparison detects newer versions."""
-        assert fuwarp.parse_calver("2025.12.19") > fuwarp.parse_calver("2025.12.18")
-        assert fuwarp.parse_calver("2025.12.18.1") > fuwarp.parse_calver("2025.12.18")
-        assert fuwarp.parse_calver("2026.1.1") > fuwarp.parse_calver("2025.12.31")
+        assert fumitm.parse_calver("2025.12.19") > fumitm.parse_calver("2025.12.18")
+        assert fumitm.parse_calver("2025.12.18.1") > fumitm.parse_calver("2025.12.18")
+        assert fumitm.parse_calver("2026.1.1") > fumitm.parse_calver("2025.12.31")
 
     def test_version_comparison_older(self):
         """Test version comparison detects older versions."""
-        assert fuwarp.parse_calver("2025.12.17") < fuwarp.parse_calver("2025.12.18")
-        assert fuwarp.parse_calver("2025.12.18") < fuwarp.parse_calver("2025.12.18.1")
-        assert fuwarp.parse_calver("2024.12.31") < fuwarp.parse_calver("2025.1.1")
+        assert fumitm.parse_calver("2025.12.17") < fumitm.parse_calver("2025.12.18")
+        assert fumitm.parse_calver("2025.12.18") < fumitm.parse_calver("2025.12.18.1")
+        assert fumitm.parse_calver("2024.12.31") < fumitm.parse_calver("2025.1.1")
 
     def test_version_comparison_equal(self):
         """Test version comparison with equal versions."""
-        assert fuwarp.parse_calver("2025.12.18") == fuwarp.parse_calver("2025.12.18")
+        assert fumitm.parse_calver("2025.12.18") == fumitm.parse_calver("2025.12.18")
         # Note: (2025, 12, 18, 0) should equal (2025, 12, 18, 0)
-        assert fuwarp.parse_calver("2025.12.18") == (2025, 12, 18, 0)
+        assert fumitm.parse_calver("2025.12.18") == (2025, 12, 18, 0)
 
 
-class TestUpdateCheckCalVer(FuwarpTestCase):
+class TestUpdateCheckCalVer(FumitmTestCase):
     """Tests for CalVer-based update checking."""
 
     def test_check_for_updates_newer_available(self, tmp_path):
         """Verify update check returns True for newer version."""
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         # Mock remote file with a version far in the future
         remote_content = b'__version__ = "2099.12.31"\n# rest of file...'
 
         with patch('urllib.request.urlopen') as mock_urlopen, \
-             patch.object(fuwarp, '__version__', '2025.1.1'):
+             patch.object(fumitm, '__version__', '2025.1.1'):
             mock_response = MagicMock()
             mock_response.read.return_value = remote_content
             mock_response.__enter__ = MagicMock(return_value=mock_response)
@@ -1668,10 +1668,10 @@ class TestUpdateCheckCalVer(FuwarpTestCase):
     def test_check_for_updates_same_version(self, tmp_path):
         """Verify update check returns False for same version."""
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         # Mock remote file with same version as local
-        remote_content = f'__version__ = "{fuwarp.__version__}"\n# rest...'.encode()
+        remote_content = f'__version__ = "{fumitm.__version__}"\n# rest...'.encode()
 
         with patch('urllib.request.urlopen') as mock_urlopen:
             mock_response = MagicMock()
@@ -1686,12 +1686,12 @@ class TestUpdateCheckCalVer(FuwarpTestCase):
     def test_check_for_updates_older_remote(self, tmp_path):
         """Verify update check returns False if remote is older."""
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         remote_content = b'__version__ = "2020.1.1"\n# rest...'
 
         with patch('urllib.request.urlopen') as mock_urlopen, \
-             patch.object(fuwarp, '__version__', '2025.12.18'):
+             patch.object(fumitm, '__version__', '2025.12.18'):
             mock_response = MagicMock()
             mock_response.read.return_value = remote_content
             mock_response.__enter__ = MagicMock(return_value=mock_response)
@@ -1704,7 +1704,7 @@ class TestUpdateCheckCalVer(FuwarpTestCase):
     def test_check_for_updates_no_version_in_remote(self, tmp_path):
         """Verify graceful handling when remote has no version."""
         with patch('platform.system', return_value='Darwin'):
-            instance = fuwarp.FuwarpPython(mode='status')
+            instance = fumitm.FumitmPython(mode='status')
 
         remote_content = b'# file without __version__\nprint("hello")'
 

--- a/test_suite/test_fumitm_windows.py
+++ b/test_suite/test_fumitm_windows.py
@@ -1,5 +1,5 @@
 """
-Integration tests for fuwarp_windows.py
+Integration tests for fumitm_windows.py
 
 These tests verify the Windows port's functionality, particularly the
 certificate appending logic and newline handling fix for issue #13.
@@ -14,12 +14,12 @@ if sys.platform != 'win32':
     pytest.skip("Windows-only tests", allow_module_level=True)
 
 # Import test utilities
-from helpers import import_fuwarp_windows
+from helpers import import_fumitm_windows
 import mock_data
 
 
 # Import the Windows module using our helper
-fuwarp_windows = import_fuwarp_windows()
+fumitm_windows = import_fumitm_windows()
 
 
 class TestCertificateAppendingWindows:
@@ -51,7 +51,7 @@ class TestCertificateAppendingWindows:
 
         # Create instance and call append_certificate_if_missing
         with patch('platform.system', return_value='Windows'):
-            instance = fuwarp_windows.FuwarpWindows(mode='install', debug=True)
+            instance = fumitm_windows.FumitmWindows(mode='install', debug=True)
             result = instance.append_certificate_if_missing(str(cert_file), str(bundle_file))
 
         assert result is True
@@ -94,7 +94,7 @@ class TestCertificateAppendingWindows:
 
         # Call append
         with patch('platform.system', return_value='Windows'):
-            instance = fuwarp_windows.FuwarpWindows(mode='install', debug=True)
+            instance = fumitm_windows.FumitmWindows(mode='install', debug=True)
             result = instance.append_certificate_if_missing(str(cert_file), str(bundle_file))
 
         assert result is True
@@ -128,7 +128,7 @@ class TestCertificateAppendingWindows:
 
         # Call append
         with patch('platform.system', return_value='Windows'):
-            instance = fuwarp_windows.FuwarpWindows(mode='install', debug=True)
+            instance = fumitm_windows.FumitmWindows(mode='install', debug=True)
             result = instance.append_certificate_if_missing(str(cert_file), str(bundle_file))
 
         assert result is True
@@ -153,7 +153,7 @@ class TestCertificateAppendingWindows:
         # Create instance and mock certificate_exists_in_file to return True
         # (since mock certificates don't work with openssl fingerprint check)
         with patch('platform.system', return_value='Windows'):
-            instance = fuwarp_windows.FuwarpWindows(mode='install', debug=True)
+            instance = fumitm_windows.FumitmWindows(mode='install', debug=True)
             with patch.object(instance, 'certificate_exists_in_file', return_value=True):
                 result = instance.append_certificate_if_missing(str(cert_file), str(bundle_file))
 
@@ -174,7 +174,7 @@ class TestCertificateAppendingWindows:
 
         # Call append
         with patch('platform.system', return_value='Windows'):
-            instance = fuwarp_windows.FuwarpWindows(mode='install', debug=True)
+            instance = fumitm_windows.FumitmWindows(mode='install', debug=True)
             result = instance.append_certificate_if_missing(str(cert_file), str(bundle_file))
 
         assert result is True
@@ -198,7 +198,7 @@ class TestCertificateAppendingWindows:
 
         # Try to append the file to itself
         with patch('platform.system', return_value='Windows'):
-            instance = fuwarp_windows.FuwarpWindows(mode='install', debug=True)
+            instance = fumitm_windows.FumitmWindows(mode='install', debug=True)
             result = instance.append_certificate_if_missing(str(test_file), str(test_file))
 
         # Should handle gracefully (return True without error)
@@ -209,28 +209,28 @@ class TestWindowsBasicFunctionality:
     """Basic functionality tests for the Windows port."""
 
     def test_instance_creation(self):
-        """Test that FuwarpWindows can be instantiated."""
+        """Test that FumitmWindows can be instantiated."""
         with patch('platform.system', return_value='Windows'):
-            instance = fuwarp_windows.FuwarpWindows(mode='status')
+            instance = fumitm_windows.FumitmWindows(mode='status')
             assert instance is not None
             assert instance.mode == 'status'
 
     def test_install_mode_setting(self):
         """Test that install mode is set correctly."""
         with patch('platform.system', return_value='Windows'):
-            instance = fuwarp_windows.FuwarpWindows(mode='install')
+            instance = fumitm_windows.FumitmWindows(mode='install')
             assert instance.is_install_mode() is True
 
-            instance = fuwarp_windows.FuwarpWindows(mode='status')
+            instance = fumitm_windows.FumitmWindows(mode='status')
             assert instance.is_install_mode() is False
 
     def test_debug_mode_setting(self):
         """Test that debug mode is set correctly."""
         with patch('platform.system', return_value='Windows'):
-            instance = fuwarp_windows.FuwarpWindows(mode='status', debug=True)
+            instance = fumitm_windows.FumitmWindows(mode='status', debug=True)
             assert instance.is_debug_mode() is True
 
-            instance = fuwarp_windows.FuwarpWindows(mode='status', debug=False)
+            instance = fumitm_windows.FumitmWindows(mode='status', debug=False)
             assert instance.is_debug_mode() is False
 
 
@@ -265,7 +265,7 @@ class TestStatusFunctionContractsWindows:
         cert_file.write_text(mock_data.MOCK_CERTIFICATE)
 
         with patch('platform.system', return_value='Windows'):
-            instance = fuwarp_windows.FuwarpWindows(mode='status')
+            instance = fumitm_windows.FumitmWindows(mode='status')
 
         status_methods = self.get_all_status_methods(instance)
 
@@ -307,7 +307,7 @@ class TestStatusFunctionContractsWindows:
         cert_file.write_text(mock_data.MOCK_CERTIFICATE)
 
         with patch('platform.system', return_value='Windows'):
-            instance = fuwarp_windows.FuwarpWindows(mode='status')
+            instance = fumitm_windows.FumitmWindows(mode='status')
 
         # Get methods excluding check_system_status (it always checks Windows store)
         status_methods = [

--- a/test_suite/test_suspicious_bundles.py
+++ b/test_suite/test_suspicious_bundles.py
@@ -6,12 +6,12 @@ users accidentally point full-bundle env vars at a single WARP CA cert.
 """
 import pytest
 
-from helpers import MockBuilder, mock_fuwarp_environment, FuwarpTestCase
+from helpers import MockBuilder, mock_fumitm_environment, FumitmTestCase
 from unittest.mock import patch, ANY
 import mock_data
 
 
-class TestSuspiciousBundles(FuwarpTestCase):
+class TestSuspiciousBundles(FumitmTestCase):
     def test_is_suspicious_when_single_cert_file(self):
         """A file with a single PEM certificate is suspicious as a full bundle."""
         small_path = f"{mock_data.HOME_DIR}/small-bundle.pem"
@@ -22,8 +22,8 @@ class TestSuspiciousBundles(FuwarpTestCase):
             .build()
         )
 
-        with mock_fuwarp_environment(mock_config):
-            instance = self.create_fuwarp_instance()
+        with mock_fumitm_environment(mock_config):
+            instance = self.create_fumitm_instance()
             suspicious, reason = instance.is_suspicious_full_bundle(small_path, None)
             assert suspicious is True
             assert "contains 1 certificate" in reason
@@ -40,8 +40,8 @@ class TestSuspiciousBundles(FuwarpTestCase):
             .build()
         )
 
-        with mock_fuwarp_environment(mock_config):
-            instance = self.create_fuwarp_instance()
+        with mock_fumitm_environment(mock_config):
+            instance = self.create_fumitm_instance()
             suspicious, reason = instance.is_suspicious_full_bundle(bundle_path, None)
             assert suspicious is False
 
@@ -63,8 +63,8 @@ class TestSuspiciousBundles(FuwarpTestCase):
             .build()
         )
 
-        with mock_fuwarp_environment(mock_config) as mocks:
-            instance = self.create_fuwarp_instance(mode='install')
+        with mock_fumitm_environment(mock_config) as mocks:
+            instance = self.create_fumitm_instance(mode='install')
             instance.setup_node_cert()  # calls setup_npm_cafile internally
             # Assert npm set called with managed path
             from helpers import assert_subprocess_called_with
@@ -91,8 +91,8 @@ class TestSuspiciousBundles(FuwarpTestCase):
             .build()
         )
 
-        with mock_fuwarp_environment(mock_config) as mocks:
-            instance = self.create_fuwarp_instance(mode='install')
+        with mock_fumitm_environment(mock_config) as mocks:
+            instance = self.create_fumitm_instance(mode='install')
             instance.setup_gcloud_cert()
             from helpers import assert_subprocess_called_with
             assert_subprocess_called_with(
@@ -118,8 +118,8 @@ class TestSuspiciousBundles(FuwarpTestCase):
             .build()
         )
 
-        with mock_fuwarp_environment(mock_config) as mocks:
-            instance = self.create_fuwarp_instance(mode='install')
+        with mock_fumitm_environment(mock_config) as mocks:
+            instance = self.create_fumitm_instance(mode='install')
             instance.setup_git_cert()
             from helpers import assert_subprocess_called_with
             assert_subprocess_called_with(
@@ -143,8 +143,8 @@ class TestSuspiciousBundles(FuwarpTestCase):
             .build()
         )
 
-        with mock_fuwarp_environment(mock_config):
-            instance = self.create_fuwarp_instance(mode='install')
+        with mock_fumitm_environment(mock_config):
+            instance = self.create_fumitm_instance(mode='install')
             with patch.object(type(instance), 'add_to_shell_config', wraps=instance.add_to_shell_config) as add_cfg:
                 instance.setup_curl_cert()
                 # Ensure we repointed CURL_CA_BUNDLE to managed path
@@ -164,8 +164,8 @@ class TestSuspiciousBundles(FuwarpTestCase):
             .build()
         )
 
-        with mock_fuwarp_environment(mock_config):
-            instance = self.create_fuwarp_instance(mode='status')
+        with mock_fumitm_environment(mock_config):
+            instance = self.create_fumitm_instance(mode='status')
             has_issues = instance.check_git_status(None)
             assert has_issues is True
 
@@ -202,12 +202,12 @@ class TestSuspiciousBundles(FuwarpTestCase):
             .build()
         )
 
-        with mock_fuwarp_environment(mock_config) as mocks:
+        with mock_fumitm_environment(mock_config) as mocks:
             # Patch CERT_PATH to match our mocked home directory
             # (CERT_PATH is set at module import time before mocks)
-            import fuwarp
-            with patch.object(fuwarp, 'CERT_PATH', cert_path):
-                instance = self.create_fuwarp_instance(mode='install')
+            import fumitm
+            with patch.object(fumitm, 'CERT_PATH', cert_path):
+                instance = self.create_fumitm_instance(mode='install')
                 with patch('pathlib.Path.touch'):
                     instance.setup_node_cert()
                 # Key assertion: npm should be repointed to managed bundle


### PR DESCRIPTION
## Summary
- Global rename of `fuwarp`/`Fuwarp` to `fumitm`/`Fumitm` across all files, class names, function names, variables, URLs, and documentation
- Renames 4 files: `fuwarp.py`, `fuwarp_windows.py`, `test_fuwarp_integration.py`, `test_fuwarp_windows.py`
- Updates project description to reflect broader MITM proxy scope (#51)

## Test plan
- [x] All 79 integration tests pass after rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)