### PR TITLE
fix: JAMF deployment — PATH augmentation, git TLS detection, ToolResult accuracy

### DIFF
--- a/fumitm.py
+++ b/fumitm.py
@@ -843,7 +843,18 @@ class FumitmPython:
     def command_exists(self, cmd):
         """Check if a command exists."""
         return shutil.which(cmd) is not None
-    
+
+    def _is_apple_git(self):
+        """True when the active git binary is Apple's SecureTransport build."""
+        try:
+            result = subprocess.run(
+                ['git', 'version'],
+                capture_output=True, text=True, timeout=5,
+            )
+            return 'Apple Git' in result.stdout
+        except Exception:
+            return False
+
     def is_writable(self, path):
         """Check if a file/directory is writable."""
         if os.path.isfile(path):
@@ -907,6 +918,29 @@ class FumitmPython:
         self._target_uid = pw.pw_uid
         self._target_gid = pw.pw_gid
         os.environ['HOME'] = pw.pw_dir
+
+        # Augment PATH so command_exists() finds user-installed tools.
+        # Root's PATH typically lacks Homebrew and user-local bin directories.
+        brew_prefix = (
+            '/opt/homebrew/bin'
+            if platform.machine() == 'arm64'
+            else '/usr/local/bin'
+        )
+        user_paths = [
+            brew_prefix,
+            os.path.join(pw.pw_dir, '.local/bin'),
+        ]
+        current = os.environ.get('PATH', '')
+        current_entries = current.split(os.pathsep)
+        for p in reversed(user_paths):
+            try:
+                exists = os.path.isdir(p)
+            except (OSError, TypeError):
+                exists = False
+            if exists and p not in current_entries:
+                current = p + os.pathsep + current
+        os.environ['PATH'] = current
+        self.print_debug("Augmented PATH with user tool directories")
 
     @staticmethod
     def _detect_console_user():
@@ -2215,7 +2249,7 @@ class FumitmPython:
                     if result.stderr:
                         self.print_debug(result.stderr.strip())
                     return ToolResult('brew-cacerts', 'failed', 'brew postinstall ca-certificates failed')
-            return
+            return ToolResult('brew-cacerts', 'skipped', 'Dry run')
 
         if self.certificate_exists_in_file(self.cert_path, bundle_path):
             self.print_debug(
@@ -2264,7 +2298,7 @@ class FumitmPython:
     def setup_node_cert(self):
         """Setup Node.js certificate."""
         if not self.command_exists('node'):
-            return
+            return ToolResult('node', 'skipped', 'node not found in PATH')
         
         shell_type = self.detect_shell()
         shell_config = self.get_shell_config(shell_type)
@@ -2327,6 +2361,8 @@ class FumitmPython:
 
                                 self.add_to_shell_config("NODE_EXTRA_CA_CERTS", new_path, shell_config)
                                 self.print_info(f"Created new certificate bundle at {new_path}")
+                            else:
+                                return ToolResult('node', 'skipped', 'User declined alternative path')
                     else:
                         if not self.is_install_mode():
                             self.print_action(f"Would append proxy certificate to {node_extra_ca_certs}")
@@ -2334,10 +2370,10 @@ class FumitmPython:
                             self.print_info(f"Appending proxy certificate to {node_extra_ca_certs}")
                             self.safe_append_certificate(self.cert_path, node_extra_ca_certs)
             else:
-                needs_setup = True
                 self.print_info("Configuring Node.js certificate...")
                 self.print_warn(f"NODE_EXTRA_CA_CERTS points to a non-existent file: {node_extra_ca_certs}")
                 self.print_warn("Please fix this manually")
+                return ToolResult('node', 'failed', f'NODE_EXTRA_CA_CERTS points to non-existent file: {node_extra_ca_certs}')
         else:
             needs_setup = True
             self.print_info("Configuring Node.js certificate...")
@@ -2367,6 +2403,12 @@ class FumitmPython:
         # Cleanup stale yarn/pnpm configs that might override NODE_EXTRA_CA_CERTS
         self.cleanup_yarn_cafile()
         self.cleanup_pnpm_cafile()
+
+        if not needs_setup:
+            return ToolResult('node', 'already_ok', 'Node.js certificate already configured')
+        if self.is_install_mode():
+            return ToolResult('node', 'configured', 'Configured Node.js certificate')
+        return ToolResult('node', 'skipped', 'Dry run')
 
     def setup_npm_cafile(self):
         """Setup npm cafile."""
@@ -2610,7 +2652,7 @@ class FumitmPython:
         """Setup Python certificate."""
         if not self.command_exists('python3') and not self.command_exists('python'):
             self.print_info("Python not found, skipping Python setup")
-            return
+            return ToolResult('python', 'skipped', 'python not found in PATH')
 
         # Note: Unlike gcloud which uses a consistent system trust store, different
         # Python installations (system, Homebrew, venvs) may have different trust
@@ -2634,7 +2676,8 @@ class FumitmPython:
                     self.print_error(f"Cannot write to {requests_ca_bundle} (permission denied)")
                     new_path = self.suggest_user_path(requests_ca_bundle, "python")
                     self.print_warn(f"Suggesting alternative path: {new_path}")
-                    
+                    needs_setup = True
+
                     if not self.is_install_mode():
                         self.print_action(f"Would create directory: {os.path.dirname(new_path)}")
                         self.print_action(f"Would copy {requests_ca_bundle} to {new_path}")
@@ -2662,6 +2705,8 @@ class FumitmPython:
                             self.add_to_shell_config("SSL_CERT_FILE", new_path, shell_config)
                             self.add_to_shell_config("CURL_CA_BUNDLE", new_path, shell_config)
                             self.print_info(f"Created new certificate bundle at {new_path}")
+                        else:
+                            return ToolResult('python', 'skipped', 'User declined alternative path')
                 else:
                     # Check if the existing bundle looks suspicious (likely just WARP CA)
                     suspicious, reason = self.is_suspicious_full_bundle(requests_ca_bundle, self.cert_path)
@@ -2672,6 +2717,7 @@ class FumitmPython:
                         if not self.is_install_mode():
                             self.print_action(f"Would create full CA bundle at {python_bundle}")
                             self.print_action(f"Would repoint REQUESTS_CA_BUNDLE to {python_bundle}")
+                            return ToolResult('python', 'skipped', 'Dry run')
                         else:
                             self.create_bundle_with_system_certs(python_bundle)
                             self.safe_append_certificate(self.cert_path, python_bundle)
@@ -2679,7 +2725,7 @@ class FumitmPython:
                             self.add_to_shell_config("SSL_CERT_FILE", python_bundle, shell_config)
                             self.add_to_shell_config("CURL_CA_BUNDLE", python_bundle, shell_config)
                             self.print_info(f"Repointed REQUESTS_CA_BUNDLE to managed bundle: {python_bundle}")
-                        return
+                            return ToolResult('python', 'configured', 'Repointed suspicious REQUESTS_CA_BUNDLE')
 
                     # Check if the file contains our certificate using normalized comparison
                     if not self.certificate_exists_in_file(self.cert_path, requests_ca_bundle):
@@ -2698,16 +2744,17 @@ class FumitmPython:
                         shell_config = self.get_shell_config(shell_type)
                         ssl_cert_file = os.environ.get('SSL_CERT_FILE', '')
                         if not ssl_cert_file:
+                            needs_setup = True
                             if not self.is_install_mode():
                                 self.print_action(f"Would set SSL_CERT_FILE to {requests_ca_bundle}")
                             else:
                                 self.add_to_shell_config("SSL_CERT_FILE", requests_ca_bundle, shell_config)
                                 self.print_info(f"Set SSL_CERT_FILE to {requests_ca_bundle}")
             else:
-                needs_setup = True
                 self.print_info("Configuring Python certificate...")
                 self.print_info(f"REQUESTS_CA_BUNDLE is already set to: {requests_ca_bundle}")
                 self.print_warn(f"REQUESTS_CA_BUNDLE points to a non-existent file: {requests_ca_bundle}")
+                return ToolResult('python', 'failed', f'REQUESTS_CA_BUNDLE points to non-existent file: {requests_ca_bundle}')
         else:
             needs_setup = True
             self.print_info("Configuring Python certificate...")
@@ -2732,6 +2779,7 @@ class FumitmPython:
             if os.path.exists(ssl_cert_file):
                 suspicious, reason = self.is_suspicious_full_bundle(ssl_cert_file, self.cert_path)
                 if suspicious:
+                    needs_setup = True
                     self.print_info("Configuring SSL_CERT_FILE...")
                     self.print_warn(f"SSL_CERT_FILE looks suspiciously small ({reason})")
                     if not self.is_install_mode():
@@ -2744,6 +2792,7 @@ class FumitmPython:
                         self.add_to_shell_config("SSL_CERT_FILE", python_bundle, shell_config)
                         self.print_info(f"Repointed SSL_CERT_FILE to managed bundle: {python_bundle}")
                 elif not self.certificate_exists_in_file(self.cert_path, ssl_cert_file):
+                    needs_setup = True
                     self.print_info("Configuring SSL_CERT_FILE...")
                     self.print_warn("SSL_CERT_FILE doesn't contain proxy certificate")
                     if not self.is_install_mode():
@@ -2755,6 +2804,7 @@ class FumitmPython:
                         self.add_to_shell_config("SSL_CERT_FILE", python_bundle, shell_config)
                         self.print_info(f"Repointed SSL_CERT_FILE to managed bundle: {python_bundle}")
             else:
+                needs_setup = True
                 self.print_info("Configuring SSL_CERT_FILE...")
                 self.print_warn(f"SSL_CERT_FILE points to non-existent file: {ssl_cert_file}")
                 if not self.is_install_mode():
@@ -2765,6 +2815,12 @@ class FumitmPython:
                         self.safe_append_certificate(self.cert_path, python_bundle)
                     self.add_to_shell_config("SSL_CERT_FILE", python_bundle, shell_config)
                     self.print_info(f"Repointed SSL_CERT_FILE to managed bundle: {python_bundle}")
+
+        if not needs_setup:
+            return ToolResult('python', 'already_ok', 'Python certificate already configured')
+        if self.is_install_mode():
+            return ToolResult('python', 'configured', 'Configured Python certificate')
+        return ToolResult('python', 'skipped', 'Dry run')
 
     def _ensure_gcloud_properties(self, ca_bundle):
         """Pre-create ~/.config/gcloud/properties with custom_ca_certs_file.
@@ -2788,10 +2844,10 @@ class FumitmPython:
                     if stripped.startswith("custom_ca_certs_file"):
                         current_value = stripped.split("=", 1)[-1].strip()
                         if current_value == ca_bundle:
-                            return
+                            return False
                         if os.path.exists(current_value) and \
                                 self.certificate_exists_in_file(self.cert_path, current_value):
-                            return
+                            return False
                 # Existing value is stale or wrong — replace it
                 lines = content.splitlines()
                 new_lines = []
@@ -2807,7 +2863,7 @@ class FumitmPython:
                         f.write('\n'.join(new_lines) + '\n')
                     self._fix_ownership(properties_file)
                     self.print_info(f"Updated custom_ca_certs_file in {properties_file}")
-                return
+                return True
 
             # File exists but no custom_ca_certs_file — append under [core]
             if "[core]" in content:
@@ -2840,33 +2896,48 @@ class FumitmPython:
                     f.write(f"[core]\n{target_line}\n")
                 self._fix_ownership(properties_file)
                 self.print_info(f"Created {properties_file} with custom_ca_certs_file")
+        return True
 
     def setup_gcloud_cert(self):
         """Setup gcloud certificate."""
         # Pre-create the gcloud properties file so that future gcloud installs
         # (e.g. `brew install --cask gcloud-cli`) can bootstrap behind a MITM
         # proxy. Also set the env var for direct gcloud invocations.
+        pre_bootstrap = False
         python_bundle = os.path.expanduser("~/.python-ca-bundle.pem")
         if os.path.exists(python_bundle):
-            self._ensure_gcloud_properties(python_bundle)
+            props_changed = self._ensure_gcloud_properties(python_bundle)
             shell_type = self.detect_shell()
             shell_config = self.get_shell_config(shell_type)
+            env_var = "CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE"
+            already_in_shell = False
+            if os.path.exists(shell_config):
+                with open(shell_config, 'r') as f:
+                    already_in_shell = (
+                        f'export {env_var}="{python_bundle}"'
+                        in f.read()
+                    )
             self.add_to_shell_config(
-                "CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE",
+                env_var,
                 python_bundle,
                 shell_config,
             )
+            pre_bootstrap = props_changed or not already_in_shell
 
         if not self.command_exists('gcloud'):
             self.print_info("gcloud not found, skipping gcloud setup")
-            return
+            if pre_bootstrap:
+                if self.is_install_mode():
+                    return ToolResult('gcloud', 'configured', 'Pre-created gcloud properties for future install')
+                return ToolResult('gcloud', 'skipped', 'Dry run')
+            return ToolResult('gcloud', 'skipped', 'gcloud not found in PATH')
 
         # First check if gcloud already works (e.g., via system trust store)
         # If it works, don't add unnecessary configuration
         verify_result = self.verify_connection("gcloud")
         if verify_result == "WORKING":
             self.print_debug("gcloud already works via system trust, skipping configuration")
-            return
+            return ToolResult('gcloud', 'already_ok', 'Works via system trust store')
 
         gcloud_cert_dir = os.path.expanduser("~/.config/gcloud/certs")
         gcloud_bundle = os.path.join(gcloud_cert_dir, "combined-ca-bundle.pem")
@@ -2900,7 +2971,8 @@ class FumitmPython:
                     self.safe_append_certificate(self.cert_path, gcloud_bundle)
                     subprocess.run(['gcloud', 'config', 'set', 'core/custom_ca_certs_file', gcloud_bundle], capture_output=True, timeout=30)
                     self.print_info(f"Repointed gcloud custom CA file to managed bundle: {gcloud_bundle}")
-                return
+                    return ToolResult('gcloud', 'configured', 'Repointed suspicious gcloud CA file')
+                return ToolResult('gcloud', 'skipped', 'Dry run')
 
             # Check if current CA file contains our certificate using normalized comparison
             if not self.certificate_exists_in_file(self.cert_path, current_ca_file):
@@ -2909,7 +2981,7 @@ class FumitmPython:
             needs_setup = True
 
         if not needs_setup:
-            return
+            return ToolResult('gcloud', 'already_ok', 'gcloud certificate already configured')
 
         self.print_info("Configuring gcloud certificate...")
         
@@ -2930,17 +3002,18 @@ class FumitmPython:
             else:
                 if not self.is_install_mode():
                     self.print_action("Would ask to update gcloud CA configuration")
-                    return
+                    return ToolResult('gcloud', 'skipped', 'Dry run')
                 else:
                     response = self._prompt("Do you want to update it? (y/N) ")
                     if response.lower() != 'y':
-                        return
+                        return ToolResult('gcloud', 'skipped', 'User declined')
         
         if not self.is_install_mode():
             self.print_action(f"Would create directory: {gcloud_cert_dir}")
             self.print_action(f"Would create gcloud CA bundle at {gcloud_bundle}")
             self.print_action("Would copy system certificates and append proxy certificate")
             self.print_action(f"Would run: gcloud config set core/custom_ca_certs_file {gcloud_bundle}")
+            return ToolResult('gcloud', 'skipped', 'Dry run')
         else:
             # Create combined bundle
             self.print_info(f"Creating gcloud CA bundle at {gcloud_bundle}")
@@ -2962,13 +3035,15 @@ class FumitmPython:
                         subprocess.run(['gcloud', 'info', '--run-diagnostics'], timeout=10)
                     except subprocess.TimeoutExpired:
                         self.print_warn("gcloud diagnostics timed out, skipping")
+                return ToolResult('gcloud', 'configured', 'Configured gcloud certificate')
             else:
                 self.print_error("Failed to configure gcloud")
+                return ToolResult('gcloud', 'failed', 'Failed to configure gcloud')
 
     def setup_git_cert(self):
         """Setup Git sslCAInfo to a managed full bundle."""
         if not self.command_exists('git'):
-            return
+            return ToolResult('git', 'skipped', 'git not found in PATH')
         git_bundle = os.path.join(self.bundle_dir, "git/ca-bundle.pem")
         # Check current setting
         try:
@@ -2991,23 +3066,41 @@ class FumitmPython:
                     self.print_info("Configuring Git certificate...")
                     self.print_warn(f"Existing git http.sslCAInfo looks suspiciously small ({reason})")
             else:
-                # Path missing — don't configure by default; Git uses system trust store
-                return
+                if self._is_apple_git():
+                    return ToolResult(
+                        'git', 'already_ok',
+                        'sslCAInfo path missing; Apple Git uses system trust',
+                    )
+                repoint = True
+                self.print_info("Configuring Git certificate...")
+                self.print_info(
+                    f"http.sslCAInfo points to non-existent file: {current_ca}"
+                )
         else:
-            # Not set — Git uses system trust store when not configured
-            return
+            if self._is_apple_git():
+                return ToolResult(
+                    'git', 'already_ok',
+                    'Uses system trust store (Apple Git)',
+                )
+            repoint = True
+            self.print_info("Configuring Git certificate...")
+            self.print_info(
+                "http.sslCAInfo not set and git is OpenSSL-linked"
+                " (needs explicit CA bundle)"
+            )
         if not repoint:
-            return
+            return ToolResult('git', 'already_ok', 'sslCAInfo already correct')
         if not self.is_install_mode():
             self.print_action(f"Would create Git CA bundle at {git_bundle}")
             self.print_action(f"Would run: git config --global http.sslCAInfo {git_bundle}")
-            return
+            return ToolResult('git', 'skipped', 'Dry run')
         # Build full bundle and configure
         self._safe_makedirs(os.path.dirname(git_bundle))
         self.create_bundle_with_system_certs(git_bundle)
         self.safe_append_certificate(self.cert_path, git_bundle)
         subprocess.run(['git', 'config', '--global', 'http.sslCAInfo', git_bundle], capture_output=True, text=True)
         self.print_info(f"Configured git http.sslCAInfo to: {git_bundle}")
+        return ToolResult('git', 'configured', f'Set http.sslCAInfo to {git_bundle}')
 
     def setup_curl_cert(self):
         """Setup curl certificate configuration.
@@ -3019,14 +3112,14 @@ class FumitmPython:
         4. curl fails with no CURL_CA_BUNDLE set - configure it
         """
         if not self.command_exists('curl'):
-            return
+            return ToolResult('curl', 'skipped', 'curl not found in PATH')
 
         # First check if curl already works (e.g., via system trust store)
         # If it works, don't add unnecessary configuration
         verify_result = self.verify_connection("curl")
         if verify_result == "WORKING":
             self.print_debug("curl already works via system trust, skipping configuration")
-            return
+            return ToolResult('curl', 'already_ok', 'Works via system trust store')
 
         curl_bundle = os.path.join(self.bundle_dir, "curl/ca-bundle.pem")
         curl_env = os.environ.get('CURL_CA_BUNDLE', '')
@@ -3040,14 +3133,14 @@ class FumitmPython:
                 if not self.is_install_mode():
                     self.print_action(f"Would create curl CA bundle at {curl_bundle}")
                     self.print_action(f"Would repoint CURL_CA_BUNDLE to {curl_bundle}")
-                    return
+                    return ToolResult('curl', 'skipped', 'Dry run')
             elif not os.path.exists(curl_env):
                 self.print_info("Configuring curl certificate bundle...")
                 self.print_warn(f"CURL_CA_BUNDLE points to non-existent file: {curl_env}")
                 if not self.is_install_mode():
                     self.print_action(f"Would create curl CA bundle at {curl_bundle}")
                     self.print_action(f"Would repoint CURL_CA_BUNDLE to {curl_bundle}")
-                    return
+                    return ToolResult('curl', 'skipped', 'Dry run')
             else:
                 suspicious, reason = self.is_suspicious_full_bundle(curl_env, self.cert_path)
                 if suspicious:
@@ -3056,20 +3149,20 @@ class FumitmPython:
                     if not self.is_install_mode():
                         self.print_action(f"Would create curl CA bundle at {curl_bundle}")
                         self.print_action(f"Would repoint CURL_CA_BUNDLE to {curl_bundle}")
-                        return
+                        return ToolResult('curl', 'skipped', 'Dry run')
                 else:
                     # Bundle exists and looks OK but curl still doesn't work
                     # This might be a different issue - don't touch it
                     self.print_warn("curl connection failed but CURL_CA_BUNDLE looks valid")
                     self.print_info("This may require manual investigation")
-                    return
+                    return ToolResult('curl', 'already_ok', 'CURL_CA_BUNDLE looks valid; may need manual investigation')
         else:
             # Case 2: No CURL_CA_BUNDLE set and curl doesn't work
             self.print_info("Configuring curl certificate bundle...")
             if not self.is_install_mode():
                 self.print_action(f"Would create curl CA bundle at {curl_bundle}")
                 self.print_action(f"Would set CURL_CA_BUNDLE={curl_bundle}")
-                return
+                return ToolResult('curl', 'skipped', 'Dry run')
 
         # Create the bundle and configure
         self._safe_makedirs(os.path.dirname(curl_bundle))
@@ -3079,6 +3172,7 @@ class FumitmPython:
         shell_config = self.get_shell_config(shell_type)
         self.add_to_shell_config("CURL_CA_BUNDLE", curl_bundle, shell_config)
         self.print_info(f"Configured CURL_CA_BUNDLE to: {curl_bundle}")
+        return ToolResult('curl', 'configured', f'Set CURL_CA_BUNDLE to {curl_bundle}')
 
     def setup_aws_cert(self):
         """Setup AWS CLI certificate configuration.
@@ -3088,7 +3182,7 @@ class FumitmPython:
         aws cli commands (e.g., aws configure sso, aws s3 ls).
         """
         if not self.command_exists('aws'):
-            return
+            return ToolResult('aws', 'skipped', 'aws not found in PATH')
 
         aws_bundle = os.path.join(self.bundle_dir, "aws/ca-bundle.pem")
         aws_env = os.environ.get('AWS_CA_BUNDLE', '')
@@ -3103,14 +3197,14 @@ class FumitmPython:
                 if not self.is_install_mode():
                     self.print_action(f"Would create AWS CA bundle at {aws_bundle}")
                     self.print_action(f"Would repoint AWS_CA_BUNDLE to {aws_bundle}")
-                    return
+                    return ToolResult('aws', 'skipped', 'Dry run')
             elif not os.path.exists(aws_env):
                 self.print_info("Configuring AWS CLI certificate bundle...")
                 self.print_warn(f"AWS_CA_BUNDLE points to non-existent file: {aws_env}")
                 if not self.is_install_mode():
                     self.print_action(f"Would create AWS CA bundle at {aws_bundle}")
                     self.print_action(f"Would repoint AWS_CA_BUNDLE to {aws_bundle}")
-                    return
+                    return ToolResult('aws', 'skipped', 'Dry run')
             else:
                 suspicious, reason = self.is_suspicious_full_bundle(aws_env, self.cert_path)
                 if suspicious:
@@ -3119,7 +3213,7 @@ class FumitmPython:
                     if not self.is_install_mode():
                         self.print_action(f"Would create AWS CA bundle at {aws_bundle}")
                         self.print_action(f"Would repoint AWS_CA_BUNDLE to {aws_bundle}")
-                        return
+                        return ToolResult('aws', 'skipped', 'Dry run')
                 elif not self.certificate_likely_exists_in_file(self.cert_path, aws_env):
                     # Bundle exists and looks OK but doesn't contain our proxy cert
                     self.print_info("Configuring AWS CLI certificate bundle...")
@@ -3127,7 +3221,7 @@ class FumitmPython:
                     if not self.is_install_mode():
                         self.print_action(f"Would create AWS CA bundle at {aws_bundle}")
                         self.print_action(f"Would repoint AWS_CA_BUNDLE to {aws_bundle}")
-                        return
+                        return ToolResult('aws', 'skipped', 'Dry run')
                 else:
                     if verify_result == "WORKING":
                         self.print_debug("AWS CLI already works with configured bundle, skipping configuration")
@@ -3135,17 +3229,17 @@ class FumitmPython:
                         # Bundle exists, looks OK, and contains our cert — unclear why it fails
                         self.print_warn("AWS CLI connection failed but AWS_CA_BUNDLE looks valid")
                         self.print_info("This may require manual investigation")
-                    return
+                    return ToolResult('aws', 'already_ok', 'AWS_CA_BUNDLE looks valid')
         else:
             if verify_result == "WORKING":
                 self.print_debug("AWS CLI already works via system trust, skipping configuration")
-                return
+                return ToolResult('aws', 'already_ok', 'Works via system trust store')
             # Case 2: No AWS_CA_BUNDLE set and aws doesn't work
             self.print_info("Configuring AWS CLI certificate bundle...")
             if not self.is_install_mode():
                 self.print_action(f"Would create AWS CA bundle at {aws_bundle}")
                 self.print_action(f"Would set AWS_CA_BUNDLE={aws_bundle}")
-                return
+                return ToolResult('aws', 'skipped', 'Dry run')
 
         # Create the bundle and configure
         self._safe_makedirs(os.path.dirname(aws_bundle))
@@ -3155,6 +3249,7 @@ class FumitmPython:
         shell_config = self.get_shell_config(shell_type)
         self.add_to_shell_config("AWS_CA_BUNDLE", aws_bundle, shell_config)
         self.print_info(f"Configured AWS_CA_BUNDLE to: {aws_bundle}")
+        return ToolResult('aws', 'configured', f'Set AWS_CA_BUNDLE to {aws_bundle}')
 
     def check_git_status(self, temp_warp_cert):
         """Check Git configuration status for http.sslCAInfo."""
@@ -3181,7 +3276,17 @@ class FumitmPython:
                         self.print_warn(f"  ✗ http.sslCAInfo points to non-existent file: {git_ca}")
                         has_issues = True
                 else:
-                    self.print_info("  - http.sslCAInfo not configured (uses system trust store)")
+                    if self._is_apple_git():
+                        self.print_info(
+                            "  - http.sslCAInfo not configured"
+                            " (Apple Git uses system trust store)"
+                        )
+                    else:
+                        self.print_warn(
+                            "  - http.sslCAInfo not configured"
+                            " (OpenSSL-linked git needs explicit CA bundle)"
+                        )
+                        has_issues = True
             except Exception:
                 self.print_warn("  ✗ Failed to check git configuration")
                 has_issues = True
@@ -3514,12 +3619,12 @@ class FumitmPython:
         gradle_props = self.get_gradle_properties_path()
 
         if not self.command_exists('gradle') and not os.path.exists(gradle_props):
-            return
+            return ToolResult('gradle', 'skipped', 'gradle not found in PATH')
 
         cacerts = self.find_java_cacerts()
         if not cacerts:
             self.print_error("Could not find Java cacerts file for Gradle")
-            return
+            return ToolResult('gradle', 'skipped', 'Java cacerts file not found')
 
         props_to_set = {
             'systemProp.javax.net.ssl.trustStore': cacerts,
@@ -3527,7 +3632,12 @@ class FumitmPython:
             'systemProp.https.protocols': 'TLSv1.2'
         }
 
-        self.update_properties_file(gradle_props, props_to_set, "Gradle properties")
+        changed = self.update_properties_file(gradle_props, props_to_set, "Gradle properties")
+        if not changed:
+            return ToolResult('gradle', 'already_ok', 'Gradle properties already configured')
+        if self.is_install_mode():
+            return ToolResult('gradle', 'configured', 'Updated Gradle properties')
+        return ToolResult('gradle', 'skipped', 'Dry run')
 
     def setup_dbeaver_cert(self):
         """Setup DBeaver certificate."""
@@ -3587,14 +3697,14 @@ class FumitmPython:
     def setup_wget_cert(self):
         """Setup wget certificate."""
         if not self.command_exists('wget'):
-            return
+            return ToolResult('wget', 'skipped', 'wget not found in PATH')
 
         # First check if wget already works (e.g., via system trust store)
         # If it works, don't add unnecessary configuration
         verify_result = self.verify_connection("wget")
         if verify_result == "WORKING":
             self.print_debug("wget already works via system trust, skipping configuration")
-            return
+            return ToolResult('wget', 'already_ok', 'Works via system trust store')
 
         wgetrc_path = os.path.expanduser("~/.wgetrc")
         config_line = f"ca_certificate={self.cert_path}"
@@ -3602,24 +3712,25 @@ class FumitmPython:
         if os.path.exists(wgetrc_path):
             with open(wgetrc_path, 'r') as f:
                 content = f.read()
-            
+
             if "ca_certificate=" in content:
                 # Check if it's already set to our certificate
                 if self.cert_path in content:
-                    return
-                
+                    return ToolResult('wget', 'already_ok', 'wget certificate already configured')
+
                 self.print_info("Configuring wget certificate...")
                 self.print_warn(f"wget ca_certificate is already set in {wgetrc_path}")
-                
+
                 # Find current setting
                 for line in content.splitlines():
                     if line.strip().startswith("ca_certificate="):
                         self.print_info(f"Current setting: {line.strip()}")
                         break
-                
+
                 if not self.is_install_mode():
                     self.print_action(f"Would ask to update the ca_certificate in {wgetrc_path}")
                     self.print_action(f"Would set: {config_line}")
+                    return ToolResult('wget', 'skipped', 'Dry run')
                 else:
                     response = self._prompt("Do you want to update it? (y/N) ")
                     if response.lower() == 'y':
@@ -3631,29 +3742,32 @@ class FumitmPython:
                                 new_lines.append(f"#{line}")
                             else:
                                 new_lines.append(line)
-                        
+
                         # Add new entry
                         new_lines.append(config_line)
-                        
+
                         # Write back
                         with open(wgetrc_path + '.bak', 'w') as f:
                             f.write(content)
                         with open(wgetrc_path, 'w') as f:
                             f.write('\n'.join(new_lines) + '\n')
-                        
+
                         self.print_info(f"Updated wget configuration in {wgetrc_path}")
-                return
-        
+                        return ToolResult('wget', 'configured', 'Updated wget configuration')
+                    return ToolResult('wget', 'skipped', 'User declined')
+
         # File doesn't exist or doesn't have ca_certificate
         self.print_info("Configuring wget certificate...")
-        
+
         if not self.is_install_mode():
             self.print_action(f"Would add to {wgetrc_path}: {config_line}")
+            return ToolResult('wget', 'skipped', 'Dry run')
         else:
             self.print_info(f"Adding configuration to {wgetrc_path}")
             with open(wgetrc_path, 'a') as f:
                 f.write(f"\n{config_line}\n")
             self.print_info("Added ca_certificate to wget configuration")
+            return ToolResult('wget', 'configured', 'Added ca_certificate to wget configuration')
     
     def _podman_vm_running(self):
         """Check whether a Podman machine is currently running."""

--- a/test_suite/test_fumitm_integration.py
+++ b/test_suite/test_fumitm_integration.py
@@ -3169,6 +3169,284 @@ class TestToolResultAccuracy(FumitmTestCase):
             assert result.status == 'skipped'
 
 
+class TestBareReturnsFixed(FumitmTestCase):
+    """Tests that setup functions return explicit ToolResult instead of None."""
+
+    def test_node_not_found_returns_skipped(self):
+        """setup_node_cert returns skipped when node not found."""
+        instance = self.create_fumitm_instance(mode='install')
+        with patch.object(instance, 'command_exists', return_value=False):
+            result = instance.setup_node_cert()
+            assert result.status == 'skipped'
+            assert result.tool == 'node'
+
+    def test_python_not_found_returns_skipped(self):
+        """setup_python_cert returns skipped when python not found."""
+        instance = self.create_fumitm_instance(mode='install')
+        with patch.object(instance, 'command_exists', return_value=False):
+            result = instance.setup_python_cert()
+            assert result.status == 'skipped'
+            assert result.tool == 'python'
+
+    def test_gcloud_not_found_returns_skipped(self):
+        """setup_gcloud_cert returns skipped when gcloud not found."""
+        instance = self.create_fumitm_instance(mode='install')
+        with patch.object(instance, 'command_exists', return_value=False), \
+             patch('os.path.exists', return_value=False):
+            result = instance.setup_gcloud_cert()
+            assert result.status == 'skipped'
+            assert result.tool == 'gcloud'
+
+    def test_gcloud_already_works_returns_already_ok(self):
+        """setup_gcloud_cert returns already_ok when gcloud works via system trust."""
+        instance = self.create_fumitm_instance(mode='install')
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.object(instance, 'verify_connection', return_value='WORKING'), \
+             patch('os.path.exists', return_value=False):
+            result = instance.setup_gcloud_cert()
+            assert result.status == 'already_ok'
+
+    def test_curl_not_found_returns_skipped(self):
+        """setup_curl_cert returns skipped when curl not found."""
+        instance = self.create_fumitm_instance(mode='install')
+        with patch.object(instance, 'command_exists', return_value=False):
+            result = instance.setup_curl_cert()
+            assert result.status == 'skipped'
+            assert result.tool == 'curl'
+
+    def test_curl_already_works_returns_already_ok(self):
+        """setup_curl_cert returns already_ok when curl works via system trust."""
+        instance = self.create_fumitm_instance(mode='install')
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.object(instance, 'verify_connection', return_value='WORKING'):
+            result = instance.setup_curl_cert()
+            assert result.status == 'already_ok'
+
+    def test_wget_not_found_returns_skipped(self):
+        """setup_wget_cert returns skipped when wget not found."""
+        instance = self.create_fumitm_instance(mode='install')
+        with patch.object(instance, 'command_exists', return_value=False):
+            result = instance.setup_wget_cert()
+            assert result.status == 'skipped'
+            assert result.tool == 'wget'
+
+    def test_wget_already_works_returns_already_ok(self):
+        """setup_wget_cert returns already_ok when wget works via system trust."""
+        instance = self.create_fumitm_instance(mode='install')
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.object(instance, 'verify_connection', return_value='WORKING'):
+            result = instance.setup_wget_cert()
+            assert result.status == 'already_ok'
+
+    def test_gradle_not_found_returns_skipped(self):
+        """setup_gradle_cert returns skipped when gradle not found."""
+        instance = self.create_fumitm_instance(mode='install')
+        with patch.object(instance, 'command_exists', return_value=False), \
+             patch('os.path.exists', return_value=False):
+            result = instance.setup_gradle_cert()
+            assert result.status == 'skipped'
+            assert result.tool == 'gradle'
+
+    def test_brew_cacerts_status_mode_returns_skipped(self):
+        """setup_brew_cacerts returns skipped in dry-run mode when bundle missing."""
+        instance = self.create_fumitm_instance(mode='status')
+        brew_prefix = instance._get_brew_prefix()
+        bundle_path = os.path.join(brew_prefix, 'etc', 'ca-certificates', 'cert.pem')
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch('subprocess.run') as mock_run, \
+             patch('os.path.exists', return_value=False):
+            mock_run.return_value = MagicMock(returncode=0)  # brew list succeeds
+            result = instance.setup_brew_cacerts()
+            assert result.status == 'skipped'
+
+    def test_node_nonexistent_file_returns_failed(self):
+        """setup_node_cert returns failed when NODE_EXTRA_CA_CERTS points to missing file."""
+        instance = self.create_fumitm_instance(mode='install')
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.dict(os.environ, {'NODE_EXTRA_CA_CERTS': '/nonexistent/cert.pem'}), \
+             patch.object(instance, '_path_belongs_to_other_provider', return_value=None), \
+             patch('os.path.exists', return_value=False):
+            result = instance.setup_node_cert()
+            assert result.status == 'failed'
+            assert 'non-existent' in result.message
+
+    def test_python_nonexistent_requests_ca_bundle_returns_failed(self):
+        """setup_python_cert returns failed when REQUESTS_CA_BUNDLE points to missing file."""
+        instance = self.create_fumitm_instance(mode='install')
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.dict(os.environ, {'REQUESTS_CA_BUNDLE': '/nonexistent/bundle.pem'}, clear=False), \
+             patch('os.path.exists', return_value=False):
+            result = instance.setup_python_cert()
+            assert result.status == 'failed'
+            assert 'non-existent' in result.message
+
+    def test_python_healthy_requests_but_missing_ssl_cert_returns_configured(self):
+        """setup_python_cert returns configured when SSL_CERT_FILE needs setting."""
+        instance = self.create_fumitm_instance(mode='install')
+        bundle_path = '/Users/testuser/.python-ca-bundle.pem'
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.dict(os.environ, {
+                 'REQUESTS_CA_BUNDLE': bundle_path,
+                 'SSL_CERT_FILE': '',
+             }, clear=False), \
+             patch('os.path.exists', return_value=True), \
+             patch.object(instance, 'is_writable', return_value=True), \
+             patch.object(instance, 'is_suspicious_full_bundle', return_value=(False, None)), \
+             patch.object(instance, 'certificate_exists_in_file', return_value=True), \
+             patch.object(instance, 'detect_shell', return_value='zsh'), \
+             patch.object(instance, 'get_shell_config', return_value='/tmp/.zshrc'), \
+             patch.object(instance, 'add_to_shell_config') as mock_shell:
+            result = instance.setup_python_cert()
+            assert result.status == 'configured'
+            mock_shell.assert_called_with('SSL_CERT_FILE', bundle_path, '/tmp/.zshrc')
+
+    def test_gcloud_pre_bootstrap_without_gcloud_returns_configured(self):
+        """setup_gcloud_cert returns configured when pre-bootstrap changes config."""
+        instance = self.create_fumitm_instance(mode='install')
+        python_bundle = os.path.expanduser("~/.python-ca-bundle.pem")
+
+        def exists_side_effect(path):
+            return path == python_bundle
+
+        with patch.object(instance, 'command_exists', return_value=False), \
+             patch('os.path.exists', side_effect=exists_side_effect), \
+             patch.object(instance, '_ensure_gcloud_properties', return_value=True) as mock_props, \
+             patch.object(instance, 'detect_shell', return_value='zsh'), \
+             patch.object(instance, 'get_shell_config', return_value='/tmp/.zshrc'), \
+             patch.object(instance, 'add_to_shell_config') as mock_shell:
+            result = instance.setup_gcloud_cert()
+            assert result.status == 'configured'
+            mock_props.assert_called_once()
+            mock_shell.assert_called_once()
+
+    def test_gcloud_pre_bootstrap_already_configured_returns_skipped(self):
+        """setup_gcloud_cert returns skipped when pre-bootstrap is a no-op."""
+        instance = self.create_fumitm_instance(mode='install')
+        python_bundle = os.path.expanduser("~/.python-ca-bundle.pem")
+        shell_config = '/tmp/.zshrc'
+
+        def exists_side_effect(path):
+            if path == python_bundle:
+                return True
+            if path == shell_config:
+                return True
+            return False
+
+        shell_content = f'export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="{python_bundle}"\n'
+        mock_open_obj = mock_open(read_data=shell_content)
+
+        with patch.object(instance, 'command_exists', return_value=False), \
+             patch('os.path.exists', side_effect=exists_side_effect), \
+             patch.object(instance, '_ensure_gcloud_properties', return_value=False), \
+             patch.object(instance, 'detect_shell', return_value='zsh'), \
+             patch.object(instance, 'get_shell_config', return_value=shell_config), \
+             patch('builtins.open', mock_open_obj), \
+             patch.object(instance, 'add_to_shell_config'):
+            result = instance.setup_gcloud_cert()
+            assert result.status == 'skipped'
+            assert result.tool == 'gcloud'
+
+    def test_gcloud_pre_bootstrap_status_mode_returns_skipped(self):
+        """setup_gcloud_cert returns skipped (not configured) in status mode."""
+        instance = self.create_fumitm_instance(mode='status')
+        python_bundle = os.path.expanduser("~/.python-ca-bundle.pem")
+
+        def exists_side_effect(path):
+            return path == python_bundle
+
+        with patch.object(instance, 'command_exists', return_value=False), \
+             patch('os.path.exists', side_effect=exists_side_effect), \
+             patch.object(instance, '_ensure_gcloud_properties', return_value=True), \
+             patch.object(instance, 'detect_shell', return_value='zsh'), \
+             patch.object(instance, 'get_shell_config', return_value='/tmp/.zshrc'), \
+             patch.object(instance, 'add_to_shell_config'):
+            result = instance.setup_gcloud_cert()
+            assert result.status == 'skipped'
+
+    def test_gcloud_pre_bootstrap_stale_shell_export_returns_configured(self):
+        """setup_gcloud_cert returns configured when shell export has wrong value."""
+        instance = self.create_fumitm_instance(mode='install')
+        python_bundle = os.path.expanduser("~/.python-ca-bundle.pem")
+        shell_config = '/tmp/.zshrc'
+
+        def exists_side_effect(path):
+            if path == python_bundle:
+                return True
+            if path == shell_config:
+                return True
+            return False
+
+        stale = 'export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="/wrong/path.pem"\n'
+        mock_open_obj = mock_open(read_data=stale)
+
+        with patch.object(instance, 'command_exists', return_value=False), \
+             patch('os.path.exists', side_effect=exists_side_effect), \
+             patch.object(instance, '_ensure_gcloud_properties', return_value=False), \
+             patch.object(instance, 'detect_shell', return_value='zsh'), \
+             patch.object(instance, 'get_shell_config', return_value=shell_config), \
+             patch('builtins.open', mock_open_obj), \
+             patch.object(instance, 'add_to_shell_config'):
+            result = instance.setup_gcloud_cert()
+            assert result.status == 'configured'
+
+    def test_node_user_declined_fallback_returns_skipped(self):
+        """setup_node_cert returns skipped when user declines alternative path."""
+        instance = self.create_fumitm_instance(mode='install')
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.dict(os.environ, {'NODE_EXTRA_CA_CERTS': '/system/cert.pem'}), \
+             patch.object(instance, '_path_belongs_to_other_provider', return_value=None), \
+             patch('os.path.exists', return_value=True), \
+             patch.object(instance, 'certificate_exists_in_file', return_value=False), \
+             patch.object(instance, 'is_writable', return_value=False), \
+             patch.object(instance, 'suggest_user_path', return_value='/tmp/alt.pem'), \
+             patch.object(instance, '_prompt', return_value='n'):
+            result = instance.setup_node_cert()
+            assert result.status == 'skipped'
+            assert 'declined' in result.message.lower()
+
+    def test_python_unwritable_requests_ca_bundle_dry_run_returns_skipped(self):
+        """setup_python_cert returns skipped in status mode for unwritable bundle."""
+        instance = self.create_fumitm_instance(mode='status')
+        bundle = '/system/ca-bundle.pem'
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.dict(os.environ, {
+                 'REQUESTS_CA_BUNDLE': bundle,
+                 'SSL_CERT_FILE': '',
+             }, clear=False), \
+             patch('os.path.exists', return_value=True), \
+             patch.object(instance, 'is_writable', return_value=False), \
+             patch.object(instance, 'suggest_user_path', return_value='/tmp/alt.pem'):
+            result = instance.setup_python_cert()
+            assert result.status == 'skipped'
+
+    def test_python_unwritable_requests_ca_bundle_decline_returns_skipped(self):
+        """setup_python_cert returns skipped when user declines alternative path."""
+        instance = self.create_fumitm_instance(mode='install')
+        bundle = '/system/ca-bundle.pem'
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.dict(os.environ, {
+                 'REQUESTS_CA_BUNDLE': bundle,
+                 'SSL_CERT_FILE': '',
+             }, clear=False), \
+             patch('os.path.exists', return_value=True), \
+             patch.object(instance, 'is_writable', return_value=False), \
+             patch.object(instance, 'suggest_user_path', return_value='/tmp/alt.pem'), \
+             patch.object(instance, '_prompt', return_value='n'):
+            result = instance.setup_python_cert()
+            assert result.status == 'skipped'
+            assert 'declined' in result.message.lower()
+
+    def test_gradle_already_configured_returns_already_ok(self):
+        """setup_gradle_cert returns already_ok when properties already set."""
+        instance = self.create_fumitm_instance(mode='install')
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.object(instance, 'find_java_cacerts', return_value='/fake/cacerts'), \
+             patch.object(instance, 'update_properties_file', return_value=False):
+            result = instance.setup_gradle_cert()
+            assert result.status == 'already_ok'
+            assert result.tool == 'gradle'
+
+
 class TestAwsVerification(FumitmTestCase):
     """Tests for AWS CLI verify_connection and status checking."""
 
@@ -3333,20 +3611,21 @@ class TestAwsSetup(FumitmTestCase):
     """Tests for AWS CLI setup_aws_cert function."""
 
     def test_aws_not_installed_returns_early(self):
-        """setup_aws_cert returns early when aws not found."""
+        """setup_aws_cert returns skipped when aws not found."""
         instance = self.create_fumitm_instance(mode='install')
         with patch.object(instance, 'command_exists', return_value=False):
             result = instance.setup_aws_cert()
-            assert result is None  # bare return
+            assert result.status == 'skipped'
+            assert result.tool == 'aws'
 
     def test_aws_already_working_skips(self):
-        """setup_aws_cert skips when aws already works via system trust."""
+        """setup_aws_cert returns already_ok when aws works via system trust."""
         instance = self.create_fumitm_instance(mode='install')
         with patch.object(instance, 'command_exists', return_value=True), \
              patch.object(instance, 'verify_connection', return_value='WORKING'), \
              patch.dict(os.environ, {}, clear=True):
             result = instance.setup_aws_cert()
-            assert result is None  # bare return, no changes needed
+            assert result.status == 'already_ok'
 
     def test_aws_working_cross_provider_bundle_still_migrates(self):
         """setup_aws_cert should fix stale AWS_CA_BUNDLE even when aws still works."""
@@ -3377,7 +3656,7 @@ class TestAwsSetup(FumitmTestCase):
              patch.object(instance, 'verify_connection', return_value='FAILED'), \
              patch.dict(os.environ, {}, clear=True):
             result = instance.setup_aws_cert()
-            assert result is None  # returns in status mode
+            assert result.status == 'skipped'
 
     def test_aws_no_bundle_install_mode_creates_bundle(self):
         """setup_aws_cert creates bundle and configures env var when no bundle set."""
@@ -3521,6 +3800,137 @@ class TestAwsSetup(FumitmTestCase):
         assert entry['scope'] == 'user'
         assert 'setup_func' in entry
         assert 'check_func' in entry
+
+
+class TestGitTlsBackend(FumitmTestCase):
+    """Tests for git TLS backend detection (Apple Git vs OpenSSL)."""
+
+    def test_is_apple_git_true(self):
+        """_is_apple_git returns True for Apple's Git."""
+        instance = self.create_fumitm_instance()
+        mock_result = MagicMock()
+        mock_result.stdout = 'git version 2.50.1 (Apple Git-155)'
+        with patch('subprocess.run', return_value=mock_result):
+            assert instance._is_apple_git() is True
+
+    def test_is_apple_git_false(self):
+        """_is_apple_git returns False for Homebrew Git."""
+        instance = self.create_fumitm_instance()
+        mock_result = MagicMock()
+        mock_result.stdout = 'git version 2.50.0'
+        with patch('subprocess.run', return_value=mock_result):
+            assert instance._is_apple_git() is False
+
+    def test_is_apple_git_command_fails(self):
+        """_is_apple_git returns False when git command fails."""
+        instance = self.create_fumitm_instance()
+        with patch('subprocess.run', side_effect=FileNotFoundError):
+            assert instance._is_apple_git() is False
+
+    def test_git_no_sslcainfo_apple_git_returns_already_ok(self):
+        """Apple Git with no sslCAInfo returns already_ok."""
+        instance = self.create_fumitm_instance(mode='install')
+        mock_git_config = MagicMock()
+        mock_git_config.returncode = 1  # not set
+        mock_git_config.stdout = ''
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.object(instance, '_is_apple_git', return_value=True), \
+             patch('subprocess.run', return_value=mock_git_config):
+            result = instance.setup_git_cert()
+            assert result.status == 'already_ok'
+            assert 'Apple Git' in result.message
+
+    def test_git_no_sslcainfo_openssl_git_configures(self):
+        """OpenSSL Git with no sslCAInfo creates bundle in install mode."""
+        instance = self.create_fumitm_instance(mode='install')
+
+        def mock_run_side_effect(*args, **kwargs):
+            cmd = args[0]
+            result = MagicMock()
+            if cmd == ['git', 'config', '--global', 'http.sslCAInfo']:
+                result.returncode = 1
+                result.stdout = ''
+            else:
+                result.returncode = 0
+                result.stdout = ''
+            return result
+
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.object(instance, '_is_apple_git', return_value=False), \
+             patch('subprocess.run', side_effect=mock_run_side_effect), \
+             patch.object(instance, '_safe_makedirs'), \
+             patch.object(instance, 'create_bundle_with_system_certs') as mock_create, \
+             patch.object(instance, 'safe_append_certificate') as mock_append:
+            result = instance.setup_git_cert()
+            assert result.status == 'configured'
+            mock_create.assert_called_once()
+            mock_append.assert_called_once()
+
+    def test_git_no_sslcainfo_openssl_git_status_mode(self):
+        """OpenSSL Git with no sslCAInfo in status mode shows actions."""
+        instance = self.create_fumitm_instance(mode='status')
+        mock_git_config = MagicMock()
+        mock_git_config.returncode = 1
+        mock_git_config.stdout = ''
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.object(instance, '_is_apple_git', return_value=False), \
+             patch('subprocess.run', return_value=mock_git_config):
+            result = instance.setup_git_cert()
+            assert result.status == 'skipped'
+            assert 'Dry run' in result.message
+
+    def test_git_missing_path_apple_git_returns_already_ok(self):
+        """Apple Git with sslCAInfo pointing to missing file returns already_ok."""
+        instance = self.create_fumitm_instance(mode='install')
+        mock_git_config = MagicMock()
+        mock_git_config.returncode = 0
+        mock_git_config.stdout = '/nonexistent/ca-bundle.pem'
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.object(instance, '_is_apple_git', return_value=True), \
+             patch.object(instance, '_path_belongs_to_other_provider', return_value=None), \
+             patch('subprocess.run', return_value=mock_git_config), \
+             patch('os.path.exists', return_value=False):
+            result = instance.setup_git_cert()
+            assert result.status == 'already_ok'
+            assert 'Apple Git' in result.message
+
+    def test_git_missing_path_openssl_git_configures(self):
+        """OpenSSL Git with sslCAInfo pointing to missing file reconfigures."""
+        instance = self.create_fumitm_instance(mode='install')
+
+        def mock_run_side_effect(*args, **kwargs):
+            cmd = args[0]
+            result = MagicMock()
+            if cmd == ['git', 'config', '--global', 'http.sslCAInfo']:
+                result.returncode = 0
+                result.stdout = '/nonexistent/ca-bundle.pem'
+            else:
+                result.returncode = 0
+                result.stdout = ''
+            return result
+
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.object(instance, '_is_apple_git', return_value=False), \
+             patch.object(instance, '_path_belongs_to_other_provider', return_value=None), \
+             patch('subprocess.run', side_effect=mock_run_side_effect), \
+             patch('os.path.exists', return_value=False), \
+             patch.object(instance, '_safe_makedirs'), \
+             patch.object(instance, 'create_bundle_with_system_certs'), \
+             patch.object(instance, 'safe_append_certificate'):
+            result = instance.setup_git_cert()
+            assert result.status == 'configured'
+
+    def test_check_git_status_openssl_no_config_flags_issue(self):
+        """check_git_status flags issue for OpenSSL Git with no sslCAInfo."""
+        instance = self.create_fumitm_instance()
+        mock_git_config = MagicMock()
+        mock_git_config.returncode = 1
+        mock_git_config.stdout = ''
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.object(instance, '_is_apple_git', return_value=False), \
+             patch('subprocess.run', return_value=mock_git_config):
+            has_issues = instance.check_git_status(None)
+            assert has_issues is True
 
 
 if __name__ == '__main__':

--- a/test_suite/test_headless_mdm.py
+++ b/test_suite/test_headless_mdm.py
@@ -675,6 +675,70 @@ class TestRunAsUser(FumitmTestCase):
             with pytest.raises(SystemExit):
                 instance._apply_target_user('ghost@domain.com')
 
+    def test_apply_target_user_augments_path_arm64(self):
+        """_apply_target_user prepends /opt/homebrew/bin on Apple Silicon."""
+        instance = self.create_fumitm_instance()
+        fake_pw = MagicMock()
+        fake_pw.pw_uid = 501
+        fake_pw.pw_gid = 20
+        fake_pw.pw_dir = '/Users/testuser'
+        original_path = '/usr/bin:/bin:/usr/sbin:/sbin'
+        with patch('pwd.getpwnam', return_value=fake_pw), \
+             patch('platform.machine', return_value='arm64'), \
+             patch.dict(os.environ, {'PATH': original_path, 'HOME': '/root'}, clear=False), \
+             patch('os.path.isdir', return_value=True):
+            instance._apply_target_user('testuser')
+            path = os.environ['PATH']
+            assert '/opt/homebrew/bin' in path.split(os.pathsep)
+            assert path.index('/opt/homebrew/bin') < path.index('/usr/bin')
+
+    def test_apply_target_user_augments_path_x86(self):
+        """_apply_target_user prepends /usr/local/bin on Intel Macs."""
+        instance = self.create_fumitm_instance()
+        fake_pw = MagicMock()
+        fake_pw.pw_uid = 501
+        fake_pw.pw_gid = 20
+        fake_pw.pw_dir = '/Users/testuser'
+        original_path = '/usr/bin:/bin:/usr/sbin:/sbin'
+        with patch('pwd.getpwnam', return_value=fake_pw), \
+             patch('platform.machine', return_value='x86_64'), \
+             patch.dict(os.environ, {'PATH': original_path, 'HOME': '/root'}, clear=False), \
+             patch('os.path.isdir', return_value=True):
+            instance._apply_target_user('testuser')
+            path = os.environ['PATH']
+            assert '/usr/local/bin' in path.split(os.pathsep)
+
+    def test_apply_target_user_skips_nonexistent_dirs(self):
+        """_apply_target_user does not add directories that don't exist."""
+        instance = self.create_fumitm_instance()
+        fake_pw = MagicMock()
+        fake_pw.pw_uid = 501
+        fake_pw.pw_gid = 20
+        fake_pw.pw_dir = '/Users/testuser'
+        original_path = '/usr/bin:/bin'
+        with patch('pwd.getpwnam', return_value=fake_pw), \
+             patch('platform.machine', return_value='arm64'), \
+             patch.dict(os.environ, {'PATH': original_path, 'HOME': '/root'}, clear=False), \
+             patch('os.path.isdir', return_value=False):
+            instance._apply_target_user('testuser')
+            assert os.environ['PATH'] == original_path
+
+    def test_apply_target_user_no_duplicate_path_entries(self):
+        """_apply_target_user does not duplicate entries already in PATH."""
+        instance = self.create_fumitm_instance()
+        fake_pw = MagicMock()
+        fake_pw.pw_uid = 501
+        fake_pw.pw_gid = 20
+        fake_pw.pw_dir = '/Users/testuser'
+        original_path = '/opt/homebrew/bin:/usr/bin:/bin'
+        with patch('pwd.getpwnam', return_value=fake_pw), \
+             patch('platform.machine', return_value='arm64'), \
+             patch.dict(os.environ, {'PATH': original_path, 'HOME': '/root'}, clear=False), \
+             patch('os.path.isdir', return_value=True):
+            instance._apply_target_user('testuser')
+            entries = os.environ['PATH'].split(os.pathsep)
+            assert entries.count('/opt/homebrew/bin') == 1
+
 
 class TestSkipUpdateCheck(FumitmTestCase):
     """--skip-update-check prevents the GitHub HTTP call."""


### PR DESCRIPTION
## Summary

Fixes three bugs discovered during a real JAMF Pro Self Service deployment where fumitm runs as root with `--run-as-user`:

- **#80** — `command_exists()` misses Homebrew-installed tools when running as root because `_apply_target_user()` sets `$HOME` but not `$PATH`. Now prepends `/opt/homebrew/bin` (arm64) or `/usr/local/bin` (x86) and `~/.local/bin` to PATH after switching user context.

- **#82** — `setup_git_cert()` assumes unconfigured `http.sslCAInfo` means Git uses the system trust store. True for Apple Git (SecureTransport), false for Homebrew Git (OpenSSL). Adds `_is_apple_git()` detection so OpenSSL-linked Git gets an explicit CA bundle configured.

- **#81** — Bare `return` (None) in setup functions is wrapped by `_run_setup()` as `ToolResult(..., 'completed', ...)`, inflating the summary count and masking skipped tools. All ~32 bare returns across 8 setup methods are replaced with explicit `ToolResult` values categorized as `skipped`, `already_ok`, `configured`, or `failed`.

  Secondary bugs fixed during review:
  - Node/Python user-decline paths returned `configured` instead of `skipped`
  - Python unwritable REQUESTS_CA_BUNDLE dry-run returned `already_ok` instead of `skipped`
  - gcloud pre-bootstrap returned `configured` in status mode (only "Would" actions ran)
  - gcloud pre-bootstrap shell export check matched variable presence, not correct value
  - gcloud pre-bootstrap set `configured` when bundle file existed, not when helpers changed state
  - Gradle fell through without ToolResult when properties were already configured

## Test plan

- [x] 323 tests pass (`uvx pytest test_suite/ -v`)
- [ ] Smoke test: `sudo fumitm.py --fix --yes --headless --provider netskope --run-as-user $USER --log-dir /tmp/fumitm-test`
  - Verify Node.js appears in output (not silently skipped)
  - Verify summary shows accurate skipped/already_ok/configured counts
  - Verify Homebrew Git gets sslCAInfo configured if present

🤖 Generated with [Claude Code](https://claude.com/claude-code)