### PR TITLE
fix: always configure gcloud core/custom_ca_certs_file for IAP tunnel

### DIFF
--- a/fumitm.py
+++ b/fumitm.py
@@ -2932,12 +2932,13 @@ class FumitmPython:
                 return ToolResult('gcloud', 'skipped', 'Dry run')
             return ToolResult('gcloud', 'skipped', 'gcloud not found in PATH')
 
-        # First check if gcloud already works (e.g., via system trust store)
-        # If it works, don't add unnecessary configuration
-        verify_result = self.verify_connection("gcloud")
-        if verify_result == "WORKING":
-            self.print_debug("gcloud already works via system trust, skipping configuration")
-            return ToolResult('gcloud', 'already_ok', 'Works via system trust store')
+        # We do NOT short-circuit on a successful basic HTTPS check here. The
+        # IAP tunnel WebSocket path (gcloud compute ssh --tunnel-through-iap)
+        # builds its own SSL context with an explicit ca_certs path read from
+        # core/custom_ca_certs_file — it ignores the system trust store and
+        # the SSL_CERT_FILE environment variable. So we always make sure the
+        # property is set to a bundle that contains our proxy CA, even when a
+        # plain `gcloud projects list` already works.
 
         gcloud_cert_dir = os.path.expanduser("~/.config/gcloud/certs")
         gcloud_bundle = os.path.join(gcloud_cert_dir, "combined-ca-bundle.pem")
@@ -4976,7 +4977,10 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             if verify_result == "WORKING":
                 self.print_info("  ✓ gcloud can connect through proxy")
 
-                # Check if custom CA is configured (informational only)
+                # core/custom_ca_certs_file is required for the IAP tunnel
+                # WebSocket path even when basic HTTPS already works through the
+                # system trust store, so we report a missing/stale value as an
+                # issue rather than informational.
                 try:
                     result = subprocess.run(
                         ['gcloud', 'config', 'get-value', 'core/custom_ca_certs_file'],
@@ -4988,10 +4992,17 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                         self.print_info(f"  - Custom CA configured at: {gcloud_ca}")
                         if self.certificate_exists_in_file(temp_warp_cert, gcloud_ca):
                             self.print_info("  ✓ Custom CA contains current certificate")
+                        else:
+                            self.print_warn("  ✗ gcloud CA file doesn't contain current certificate")
+                            self.print_action("    Run with --fix to update the CA configuration (required for IAP tunneling)")
+                            has_issues = True
                     else:
-                        self.print_info("  - Using system certificate trust (no custom CA needed)")
+                        self.print_warn("  ✗ core/custom_ca_certs_file is not set")
+                        self.print_action("    Run with --fix to configure (required for `gcloud compute ssh --tunnel-through-iap`)")
+                        has_issues = True
                 except Exception:
-                    self.print_info("  - Using system certificate trust")
+                    self.print_warn("  ✗ Failed to check gcloud configuration")
+                    has_issues = True
             elif verify_result == "SKIPPED":
                 # Can't verify, fall back to config check
                 try:

--- a/test_suite/test_fumitm_integration.py
+++ b/test_suite/test_fumitm_integration.py
@@ -2239,7 +2239,11 @@ class TestGcloudVerification(FumitmTestCase):
             assert result == "NOT_INSTALLED"
 
     def test_check_gcloud_status_working_no_custom_ca(self, tmp_path):
-        """Test gcloud status when working without custom CA."""
+        """gcloud status flags missing core/custom_ca_certs_file even when basic HTTPS works.
+
+        IAP tunnel reads core/custom_ca_certs_file explicitly and ignores the
+        system trust store, so a working `gcloud projects list` is not enough.
+        """
         cert_file = tmp_path / "cert.pem"
         cert_file.write_text(mock_data.MOCK_CERTIFICATE)
 
@@ -2259,8 +2263,7 @@ class TestGcloudVerification(FumitmTestCase):
 
             has_issues = instance.check_gcloud_status(str(cert_file))
 
-            # Should NOT have issues when gcloud works without custom CA
-            assert has_issues is False
+            assert has_issues is True
 
     def test_check_gcloud_status_failed_suggests_fix(self, tmp_path):
         """Test gcloud status suggests fix when connection fails."""
@@ -3197,14 +3200,43 @@ class TestBareReturnsFixed(FumitmTestCase):
             assert result.status == 'skipped'
             assert result.tool == 'gcloud'
 
-    def test_gcloud_already_works_returns_already_ok(self):
-        """setup_gcloud_cert returns already_ok when gcloud works via system trust."""
+    def test_gcloud_already_configured_returns_already_ok(self):
+        """setup_gcloud_cert returns already_ok when core/custom_ca_certs_file already points to a bundle with our cert."""
         instance = self.create_fumitm_instance(mode='install')
+        existing_bundle = '/Users/testuser/.python-ca-bundle.pem'
         with patch.object(instance, 'command_exists', return_value=True), \
-             patch.object(instance, 'verify_connection', return_value='WORKING'), \
-             patch('os.path.exists', return_value=False):
-            result = instance.setup_gcloud_cert()
+             patch('os.path.exists', return_value=False), \
+             patch('subprocess.run') as mock_run, \
+             patch.object(instance, 'is_suspicious_full_bundle', return_value=(False, None)), \
+             patch.object(instance, 'certificate_exists_in_file', return_value=True):
+            mock_run.return_value = MagicMock(returncode=0, stdout=existing_bundle)
+            with patch('os.path.exists', side_effect=lambda p: p == existing_bundle):
+                result = instance.setup_gcloud_cert()
             assert result.status == 'already_ok'
+
+    def test_gcloud_iap_regression_configures_when_https_works_but_ca_unset(self):
+        """IAP regression: even if basic HTTPS works, missing core/custom_ca_certs_file must be configured.
+
+        IAP tunnel (`gcloud compute ssh --tunnel-through-iap`) reads ca_certs
+        explicitly from core/custom_ca_certs_file and ignores system trust /
+        SSL_CERT_FILE, so we must always set the property.
+        """
+        instance = self.create_fumitm_instance(mode='install')
+        gcloud_managed = os.path.expanduser("~/.config/gcloud/certs/combined-ca-bundle.pem")
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch('os.path.exists', return_value=False), \
+             patch.object(instance, '_safe_makedirs'), \
+             patch.object(instance, 'create_bundle_with_system_certs'), \
+             patch.object(instance, 'safe_append_certificate'), \
+             patch.object(instance, 'is_devcontainer', return_value=True), \
+             patch('subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout='')
+            result = instance.setup_gcloud_cert()
+            assert result.status == 'configured'
+            assert_subprocess_called_with(
+                mock_run,
+                ['gcloud', 'config', 'set', 'core/custom_ca_certs_file', gcloud_managed]
+            )
 
     def test_curl_not_found_returns_skipped(self):
         """setup_curl_cert returns skipped when curl not found."""

--- a/test_suite/test_suspicious_bundles.py
+++ b/test_suite/test_suspicious_bundles.py
@@ -84,10 +84,6 @@ class TestSuspiciousBundles(FumitmTestCase):
             .with_tools('gcloud')
             .with_file(gcloud_current, mock_data.MOCK_CERTIFICATE)
             .with_file('/etc/ssl/cert.pem', mock_data.SAMPLE_CA_BUNDLE)
-            # verify_connection("gcloud") → gcloud projects list --limit=1
-            # Return an SSL error so verify_connection returns "FAILED" and
-            # setup_gcloud_cert continues to the suspicious-bundle check.
-            .with_subprocess_response(returncode=1, stderr='ssl certificate problem')
             # gcloud config get
             .with_subprocess_response(stdout=gcloud_current)
             # gcloud config set


### PR DESCRIPTION
The IAP tunnel WebSocket path in gcloud builds its own SSLContext with an explicit ca_certs read from core/custom_ca_certs_file — it bypasses the system trust store and ignores SSL_CERT_FILE. setup_gcloud_cert previously short-circuited as already_ok whenever a plain HTTPS check worked, which left the property unset and broke `gcloud compute ssh --tunnel-through-iap` on machines where the basic HTTPS path happened to succeed via system trust.

check_gcloud_status now flags a missing/stale property as an issue instead of reporting "Using system certificate trust (no custom CA needed)".