### PR TITLE
fix: shell config writes are idempotent when value already matches

### DIFF
--- a/fumitm.py
+++ b/fumitm.py
@@ -1717,15 +1717,34 @@ class FumitmPython:
         if os.path.exists(shell_config):
             with open(shell_config, 'r') as f:
                 content = f.read()
-                
-            if f"export {var_name}=" in content:
+
+            # Find the first active (non-commented) export of this variable
+            # and compare its value to what we would write. If they already
+            # match, this is a no-op and we should not warn or prompt.
+            active_line = None
+            for line in content.splitlines():
+                stripped = line.strip()
+                if stripped.startswith('#'):
+                    continue
+                if stripped.startswith(f"export {var_name}="):
+                    active_line = stripped
+                    break
+
+            if active_line is not None:
+                rhs = active_line.split('=', 1)[1].strip()
+                if (rhs.startswith('"') and rhs.endswith('"')) or \
+                        (rhs.startswith("'") and rhs.endswith("'")):
+                    rhs = rhs[1:-1]
+                if rhs == var_value:
+                    # Already set to the desired value — quietly do nothing
+                    # so repeated runs are idempotent and we don't claim a
+                    # change in the summary or trigger a stale "reload your
+                    # shell" hint.
+                    return
+
                 self.print_warn(f"{var_name} already exists in {shell_config}")
-                # Find current value
-                for line in content.splitlines():
-                    if line.strip().startswith(f"export {var_name}="):
-                        self.print_info(f"Current value: {line.strip()}")
-                        break
-                
+                self.print_info(f"Current value: {active_line}")
+
                 if not self.is_install_mode():
                     self.print_action(f"Would ask to update {var_name} in {shell_config}")
                     self.print_action(f"Would set: export {var_name}=\"{var_value}\"")

--- a/test_suite/test_fumitm_integration.py
+++ b/test_suite/test_fumitm_integration.py
@@ -3965,5 +3965,90 @@ class TestGitTlsBackend(FumitmTestCase):
             assert has_issues is True
 
 
+class TestShellConfigIdempotency(FumitmTestCase):
+    """Ensure add_to_shell_config is a no-op when the active export already
+    matches the desired value.
+
+    Regression: previously the function only checked whether `export VAR=`
+    appeared anywhere in the file and prompted the user even when the
+    existing value was correct. Saying "y" rewrote the file with an
+    identical line, falsely flagged shell_modified, and produced a
+    "1 configured" entry plus a "source ~/.zshrc" hint on every run.
+    """
+
+    def test_idempotent_when_value_matches(self, tmp_path):
+        instance = self.create_fumitm_instance(mode='install')
+        rc = tmp_path / '.zshrc'
+        original = (
+            '# user prologue\n'
+            'export PATH="/usr/local/bin:$PATH"\n'
+            'export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="/Users/test/.python-ca-bundle.pem"\n'
+            '# user epilogue\n'
+        )
+        rc.write_text(original)
+
+        with patch.object(instance, '_prompt') as prompt:
+            instance.add_to_shell_config(
+                'CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE',
+                '/Users/test/.python-ca-bundle.pem',
+                str(rc),
+            )
+
+        assert prompt.call_count == 0, "should not prompt when value already matches"
+        assert rc.read_text() == original, "file should be untouched"
+        assert getattr(instance, 'shell_modified', False) is False
+
+    def test_prompts_and_rewrites_when_value_differs(self, tmp_path):
+        instance = self.create_fumitm_instance(mode='install')
+        rc = tmp_path / '.zshrc'
+        rc.write_text(
+            'export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="/old/path.pem"\n'
+        )
+
+        with patch.object(instance, '_prompt', return_value='y'):
+            instance.add_to_shell_config(
+                'CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE',
+                '/new/path.pem',
+                str(rc),
+            )
+
+        new_content = rc.read_text()
+        assert '#export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="/old/path.pem"' in new_content
+        assert 'export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="/new/path.pem"' in new_content
+        assert instance.shell_modified is True
+
+    def test_appends_when_only_commented_export_exists(self, tmp_path):
+        instance = self.create_fumitm_instance(mode='install')
+        rc = tmp_path / '.zshrc'
+        rc.write_text('#export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="/old/path.pem"\n')
+
+        with patch.object(instance, '_prompt') as prompt:
+            instance.add_to_shell_config(
+                'CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE',
+                '/new/path.pem',
+                str(rc),
+            )
+
+        assert prompt.call_count == 0, "commented-out lines should not trigger a prompt"
+        assert 'export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="/new/path.pem"' in rc.read_text()
+        assert instance.shell_modified is True
+
+    def test_idempotent_with_unquoted_existing_value(self, tmp_path):
+        instance = self.create_fumitm_instance(mode='install')
+        rc = tmp_path / '.zshrc'
+        original = 'export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE=/Users/test/bundle.pem\n'
+        rc.write_text(original)
+
+        with patch.object(instance, '_prompt') as prompt:
+            instance.add_to_shell_config(
+                'CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE',
+                '/Users/test/bundle.pem',
+                str(rc),
+            )
+
+        assert prompt.call_count == 0
+        assert rc.read_text() == original
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
## Summary

- `add_to_shell_config()` now compares the active (non-commented) export's value against the desired value and returns silently when they match. No warning, no prompt, no rewrite, no `shell_modified` flag.
- Commented-out leftover exports no longer trigger a false prompt; they cleanly fall through to the append branch.
- Right-hand-side parsing handles double-quoted, single-quoted, and unquoted forms.

Fixes #86

## Test plan

- [x] `uvx pytest test_fumitm_integration.py::TestShellConfigIdempotency -v` — 4 new cases (value matches, value differs, only commented line exists, unquoted match)
- [x] Full suite green: `uvx pytest test_fumitm_integration.py test_netskope_provider.py test_suspicious_bundles.py test_headless_mdm.py` — 328 passed