### PR TITLE
Add Aikido supplemental root-CA support

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -35,6 +35,8 @@ jobs:
             - 'test_suite/test_fumitm_integration.py'
             - 'test_suite/test_netskope_provider.py'
             - 'test_suite/test_suspicious_bundles.py'
+            - 'test_suite/test_aikido_root.py'
+            - 'test_suite/test_headless_mdm.py'
             - 'test_suite/helpers.py'
             - 'test_suite/mock_data.py'
           fumitm_windows:
@@ -68,7 +70,7 @@ jobs:
       working-directory: test_suite
       run: |
         source .venv/bin/activate
-        python -m pytest test_fumitm_integration.py test_netskope_provider.py test_suspicious_bundles.py -v --tb=short
+        python -m pytest test_fumitm_integration.py test_netskope_provider.py test_suspicious_bundles.py test_aikido_root.py test_headless_mdm.py -v --tb=short
 
   test-linux:
     runs-on: ubuntu-latest
@@ -97,7 +99,7 @@ jobs:
       working-directory: test_suite
       run: |
         source .venv/bin/activate
-        python -m pytest test_fumitm_integration.py test_netskope_provider.py test_suspicious_bundles.py -v --tb=short
+        python -m pytest test_fumitm_integration.py test_netskope_provider.py test_suspicious_bundles.py test_aikido_root.py test_headless_mdm.py -v --tb=short
 
   test-windows:
     runs-on: windows-latest

--- a/README-automation.md
+++ b/README-automation.md
@@ -16,13 +16,18 @@ fumitm supports JAMF Pro, Ansible, Puppet, and similar headless orchestration to
 | `--run-as-user USERNAME` | Configure certs for USERNAME's home directory (requires root). Use `auto` to detect console user on macOS. |
 | `--skip-update-check` | Skip the GitHub update check (implied by `--headless`). |
 | `--provider warp\|netskope` | Explicit provider selection (default: auto-detect). |
-| `--with-aikido` | Force-add the Aikido Endpoint Protection root CA to all bundles even if it is not auto-detected (e.g. on CI images without the agent installed). |
+| `--with-aikido` | Force-add the Aikido Endpoint Protection root CA to all bundles even if it is not auto-detected. |
+| `--aikido-cert PATH` | Path to a PEM file holding the Aikido root CA; the preferred source for `--with-aikido` on images with no live agent. Implies `--with-aikido`. |
 | `--no-aikido` | Do not add the Aikido root CA even if Aikido is detected. Mutually exclusive with `--with-aikido`. |
 
 When Aikido Endpoint Protection is present, its root CA is auto-detected and
 added to every managed bundle/keystore alongside the primary provider's root; no
-flag is required. The two flags above only override that auto-detection. Aikido
-support targets macOS/Linux; the Windows port does not yet add the Aikido root.
+flag is required. The two flags above only override that auto-detection. On a CI
+or no-agent image where no live Aikido source exists, `--with-aikido` needs the
+root supplied explicitly via `--aikido-cert`, or persisted from an earlier run at
+`~/.aikido-ca.pem`; without a source it warns and skips the supplemental root.
+Aikido support targets macOS/Linux; the Windows port does not yet add the Aikido
+root.
 
 ## Exit Codes
 

--- a/README-automation.md
+++ b/README-automation.md
@@ -16,6 +16,13 @@ fumitm supports JAMF Pro, Ansible, Puppet, and similar headless orchestration to
 | `--run-as-user USERNAME` | Configure certs for USERNAME's home directory (requires root). Use `auto` to detect console user on macOS. |
 | `--skip-update-check` | Skip the GitHub update check (implied by `--headless`). |
 | `--provider warp\|netskope` | Explicit provider selection (default: auto-detect). |
+| `--with-aikido` | Force-add the Aikido Endpoint Protection root CA to all bundles even if it is not auto-detected (e.g. on CI images without the agent installed). |
+| `--no-aikido` | Do not add the Aikido root CA even if Aikido is detected. Mutually exclusive with `--with-aikido`. |
+
+When Aikido Endpoint Protection is present, its root CA is auto-detected and
+added to every managed bundle/keystore alongside the primary provider's root; no
+flag is required. The two flags above only override that auto-detection. Aikido
+support targets macOS/Linux; the Windows port does not yet add the Aikido root.
 
 ## Exit Codes
 

--- a/README.md
+++ b/README.md
@@ -98,10 +98,12 @@ the primary provider's root — never replacing it, since traffic Aikido does no
 intercept still presents the underlying provider's certificate. This matters for
 rustls clients such as `uv`, which honor `SSL_CERT_FILE`: a bundle missing the
 Aikido root fails Aikido-intercepted hosts with `invalid peer certificate:
-UnknownIssuer`. Use `--with-aikido` to force the supplemental root on (handy in
-CI where the detection signals are absent) or `--no-aikido` to skip it. Aikido
-support currently targets macOS/Linux (`fumitm.py`); the Windows port does not
-yet add the Aikido root.
+UnknownIssuer`. Use `--with-aikido` to force the supplemental root on or
+`--no-aikido` to skip it. On a CI or no-agent image where the live detection
+signals are absent, supply the root with `--aikido-cert /path/to/aikido-root.pem`
+(it implies `--with-aikido`); fumitm also reuses a root persisted at
+`~/.aikido-ca.pem` from an earlier run. Aikido support currently targets
+macOS/Linux (`fumitm.py`); the Windows port does not yet add the Aikido root.
 
 ### Windows-Specific
 - `warp-cli.exe` command must be available 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ chmod +x ./fumitm.py
 ./fumitm.py --fix --provider warp
 ./fumitm.py --fix --provider netskope
 
+# Aikido Endpoint Protection (supplemental TLS interception) is auto-detected
+# and its root CA is added to every bundle alongside the primary provider.
+# Force it on (e.g. in CI where detection signals are absent) or off:
+./fumitm.py --fix --with-aikido
+./fumitm.py --fix --no-aikido
+
 # Running in a devcontainer/WSL?
 # See the "VS Code Devcontainers / WSL" section below.
 ```
@@ -81,6 +87,21 @@ The act of toggling your MITM off also seriously hints that you have no clue wha
 - Cloudflare WARP or Netskope Client should be installed and connected
 - `warp-cli` is needed for WARP flows. Netskope auto-detection uses known certificate paths or a running STAgent process (`nsdiag` is optional)
 - Python 3 (macOS/Linux, Windows/WSL)
+
+### Supplemental root CAs (Aikido)
+
+Some environments run **Aikido Endpoint Protection** performing *selective* TLS
+interception on top of the primary provider. fumitm auto-detects Aikido (via its
+`AikidoSecurity` support directory, combined PEM, or System Keychain entry) and
+adds the **Aikido root CA** to every bundle and keystore it manages, alongside
+the primary provider's root — never replacing it, since traffic Aikido does not
+intercept still presents the underlying provider's certificate. This matters for
+rustls clients such as `uv`, which honor `SSL_CERT_FILE`: a bundle missing the
+Aikido root fails Aikido-intercepted hosts with `invalid peer certificate:
+UnknownIssuer`. Use `--with-aikido` to force the supplemental root on (handy in
+CI where the detection signals are absent) or `--no-aikido` to skip it. Aikido
+support currently targets macOS/Linux (`fumitm.py`); the Windows port does not
+yet add the Aikido root.
 
 ### Windows-Specific
 - `warp-cli.exe` command must be available 

--- a/fumitm.py
+++ b/fumitm.py
@@ -181,6 +181,29 @@ PROVIDERS = {
     },
 }
 
+# Supplemental root CAs: vendors that perform *selective* TLS interception on
+# top of a primary provider. Unlike PROVIDERS, these are never selected to the
+# exclusion of others — when detected, their root is added to every bundle
+# fumitm builds *alongside* the primary provider's root. They are deliberately
+# kept out of PROVIDERS so _resolve_provider can never return one.
+SUPPLEMENTAL_ROOTS = {
+    'aikido': {
+        'name': 'Aikido Endpoint Protection',
+        'short_name': 'Aikido',
+        # Keychain label and subject CN both start with this; the org-specific
+        # "- org-NNNNNN" suffix varies, so we always match on the prefix.
+        'keychain_label_prefix': 'Aikido Endpoint Protection Root CA',
+        'support_dir': '/Library/Application Support/AikidoSecurity/',
+        'combined_pem': (
+            '/Library/Application Support/AikidoSecurity/'
+            'EndpointProtection/run/endpoint-protection-pip-combined-ca.pem'
+        ),
+        'cert_path': '~/.aikido-ca.pem',
+        'keytool_alias': 'aikido-root',
+        'container_cert_name': 'aikido',
+    },
+}
+
 class NonInteractiveError(Exception):
     """Raised when interactive input is needed but stdin is not a terminal."""
 
@@ -204,7 +227,7 @@ class FumitmPython:
                  headless=False, skip_update_check=False,
                  log_file=None, log_dir=None,
                  json_log_file=None, json_log_dir=None,
-                 run_as_user=None):
+                 run_as_user=None, with_aikido=False, no_aikido=False):
         self.mode = mode
         self.debug = debug
         self.shell_modified = False
@@ -265,6 +288,14 @@ class FumitmPython:
         self.provider = self._resolve_provider(provider)
         self.cert_path = os.path.expanduser(self.provider['cert_path'])
         self.bundle_dir = os.path.expanduser(self.provider['bundle_dir'])
+
+        # Resolve supplemental root CAs (e.g. Aikido) that ride alongside the
+        # primary provider. Each entry is a descriptor copy that gains a 'path'
+        # key once its root certificate is materialized by _prepare_extra_roots.
+        # Empty when none are detected, which keeps behavior byte-for-byte
+        # identical to the no-supplemental-root case.
+        self._extra_root_temp_files = []
+        self.extra_roots = self._resolve_extra_roots(with_aikido, no_aikido)
 
         # Define tool registry with tags, descriptions, and scope. Scope
         # determines what runs without user context when root runs without
@@ -492,6 +523,164 @@ class FumitmPython:
             pass
 
         return False
+
+    def _resolve_extra_roots(self, with_aikido, no_aikido):
+        """Determine which supplemental root CAs are active for this run.
+
+        A supplemental root is included when explicitly forced on, or when it is
+        auto-detected and not explicitly forced off. Returns a list of descriptor
+        copies (each tagged with its registry key); empty when none apply.
+        """
+        active = []
+        # Aikido is the only supplemental root today; the structure generalizes
+        # so future vendors slot in the same way.
+        aikido_forced_off = no_aikido
+        aikido_active = with_aikido or (not aikido_forced_off and self._detect_aikido())
+        if aikido_active:
+            entry = dict(SUPPLEMENTAL_ROOTS['aikido'])
+            entry['key'] = 'aikido'
+            active.append(entry)
+        return active
+
+    def _detect_aikido(self):
+        """Return True if Aikido Endpoint Protection appears to be present.
+
+        Any of the following is sufficient: the AikidoSecurity support directory
+        exists, the maintained combined PEM exists, or (macOS) the System
+        Keychain holds a certificate whose label starts with the Aikido root CA
+        prefix. The org-specific suffix on the label is ignored.
+        """
+        descriptor = SUPPLEMENTAL_ROOTS['aikido']
+        if os.path.isdir(descriptor['support_dir']):
+            return True
+        if os.path.exists(descriptor['combined_pem']):
+            return True
+
+        if platform.system() == 'Darwin':
+            try:
+                result = subprocess.run(
+                    ['security', 'find-certificate', '-c',
+                     descriptor['keychain_label_prefix'],
+                     '/Library/Keychains/System.keychain'],
+                    capture_output=True, text=True
+                )
+                if result.returncode == 0:
+                    return True
+            except Exception as e:
+                self.print_debug(f"Aikido keychain detection failed: {e}")
+
+        return False
+
+    def _get_aikido_root_cert(self):
+        """Retrieve the Aikido root CA certificate(s) as PEM text.
+
+        Tries the macOS System Keychain first (by label prefix), then falls back
+        to parsing the maintained combined PEM. Only certificates whose subject
+        CN starts with the Aikido root prefix are kept; the ephemeral hex-CN
+        interception intermediate is deliberately excluded.
+
+        Returns:
+            str or None: PEM text containing the Aikido root(s), or None.
+        """
+        descriptor = SUPPLEMENTAL_ROOTS['aikido']
+        prefix = descriptor['keychain_label_prefix']
+
+        # Source 1: macOS System Keychain, all matching certs by label prefix.
+        if platform.system() == 'Darwin':
+            try:
+                result = subprocess.run(
+                    ['security', 'find-certificate', '-a', '-c', prefix, '-p',
+                     '/Library/Keychains/System.keychain'],
+                    capture_output=True, text=True
+                )
+                if result.returncode == 0 and '-----BEGIN CERTIFICATE-----' in result.stdout:
+                    roots = self._filter_certs_by_cn_prefix(result.stdout, prefix)
+                    if roots:
+                        self.print_info("Using Aikido root CA from macOS System Keychain")
+                        return '\n'.join(roots)
+            except Exception as e:
+                self.print_debug(f"Aikido keychain extraction failed: {e}")
+
+        # Source 2: maintained combined PEM on disk.
+        combined = descriptor['combined_pem']
+        if os.path.exists(combined):
+            try:
+                with open(combined, 'r') as f:
+                    roots = self._filter_certs_by_cn_prefix(f.read(), prefix)
+                if roots:
+                    self.print_info(f"Using Aikido root CA from {combined}")
+                    return '\n'.join(roots)
+            except Exception as e:
+                self.print_debug(f"Could not parse Aikido combined PEM: {e}")
+
+        self.print_warn("Could not extract Aikido root CA; skipping supplemental trust")
+        return None
+
+    def _filter_certs_by_cn_prefix(self, pem_text, cn_prefix):
+        """Return the PEM blocks whose subject CN starts with cn_prefix.
+
+        Splits a PEM bundle into individual certificates and keeps only those
+        whose subject common name begins with the given prefix, validating each
+        with openssl. This is what rejects Aikido's ephemeral hex-CN
+        interception intermediate while keeping the long-lived root.
+        """
+        marker = '-----END CERTIFICATE-----'
+        blocks = []
+        for chunk in pem_text.split(marker):
+            if '-----BEGIN CERTIFICATE-----' in chunk:
+                blocks.append(chunk[chunk.index('-----BEGIN CERTIFICATE-----'):] + marker + '\n')
+
+        matching = []
+        for block in blocks:
+            subject = self._openssl_subject(block)
+            if subject is None:
+                continue
+            cn = self._subject_common_name(subject)
+            if cn and cn.startswith(cn_prefix):
+                matching.append(block.strip())
+        return matching
+
+    def _openssl_subject(self, cert_pem):
+        """Return the openssl subject line for a single PEM cert, or None if invalid."""
+        try:
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.pem', delete=False) as tf:
+                tf.write(cert_pem)
+                tmp_path = tf.name
+        except Exception:
+            return None
+        try:
+            result = subprocess.run(
+                ['openssl', 'x509', '-noout', '-subject', '-in', tmp_path],
+                capture_output=True, text=True
+            )
+            if result.returncode != 0:
+                return None
+            return result.stdout.strip()
+        except Exception:
+            return None
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+    @staticmethod
+    def _subject_common_name(subject_line):
+        """Extract the CN value from an openssl subject line, or None.
+
+        Handles the RFC 2253 form ("subject=CN=foo,O=bar"), the spaced OpenSSL 3
+        form ("subject=CN = foo, O = bar"), and the legacy slash form
+        ("subject= /CN=foo/O=bar") that LibreSSL and older builds emit.
+        """
+        if not subject_line:
+            return None
+        body = subject_line.split('=', 1)[1] if subject_line.lower().startswith('subject') else subject_line
+        # Normalize the slash-delimited legacy form into comma-delimited.
+        for token in body.replace('/', ',').split(','):
+            key, sep, value = token.partition('=')
+            if sep and key.strip().upper() == 'CN':
+                return value.strip()
+        return None
 
     def is_install_mode(self):
         return self.mode == 'install'
@@ -2154,9 +2343,246 @@ class FumitmPython:
         
         # Cache the fingerprint for later use
         self.get_cert_fingerprint()
-        
+
         return True
-    
+
+    def _prepare_extra_roots(self):
+        """Materialize each detected supplemental root CA to a file on disk.
+
+        In install mode the root is written to its persistent cert_path with
+        ownership corrected; in status mode it is written to a temp file tracked
+        for cleanup. Each surviving entry gains a 'path' key. Entries whose root
+        cannot be retrieved or validated are dropped, so downstream bundle
+        assembly silently skips them.
+        """
+        if not self.extra_roots:
+            return
+        getters = {'aikido': self._get_aikido_root_cert}
+        resolved = []
+        for entry in self.extra_roots:
+            if entry.get('path'):
+                resolved.append(entry)
+                continue
+            getter = getters.get(entry['key'])
+            pem = getter() if getter else None
+            if not pem:
+                continue
+            if not self._is_valid_pem_cert(pem):
+                self.print_warn(f"{entry['name']} root certificate is not valid PEM; skipping")
+                continue
+            path = self._write_extra_root(entry, pem)
+            if path:
+                entry['path'] = path
+                resolved.append(entry)
+        self.extra_roots = resolved
+
+    def _is_valid_pem_cert(self, pem_text):
+        """Return True if pem_text starts with a certificate openssl can parse."""
+        try:
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.pem', delete=False) as tf:
+                tf.write(pem_text)
+                tmp = tf.name
+        except Exception:
+            return False
+        try:
+            result = subprocess.run(
+                ['openssl', 'x509', '-noout', '-in', tmp], capture_output=True
+            )
+            return result.returncode == 0
+        except Exception:
+            return False
+        finally:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+
+    def _write_extra_root(self, entry, pem_text):
+        """Write a supplemental root's PEM to disk and return its path, or None."""
+        if not pem_text.endswith('\n'):
+            pem_text = pem_text + '\n'
+        if self.is_install_mode():
+            path = os.path.expanduser(entry['cert_path'])
+            try:
+                with open(path, 'w') as f:
+                    f.write(pem_text)
+                self._fix_ownership(path)
+                self.print_info(f"Saved {entry['name']} root CA to {path}")
+                return path
+            except Exception as e:
+                self.print_error(f"Could not save {entry['name']} root CA: {e}")
+                return None
+        try:
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.pem', delete=False) as tf:
+                tf.write(pem_text)
+                path = tf.name
+            self._extra_root_temp_files.append(path)
+            return path
+        except Exception as e:
+            self.print_debug(f"Could not write temp {entry['name']} root: {e}")
+            return None
+
+    def _cleanup_extra_root_temp_files(self):
+        """Remove any temp files created for supplemental roots in status mode."""
+        for path in self._extra_root_temp_files:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+        self._extra_root_temp_files = []
+
+    def _announce_extra_roots(self):
+        """Print a one-line notice for each active supplemental root CA."""
+        for entry in self.extra_roots:
+            if entry.get('path'):
+                self.print_info(
+                    f"{entry['name']} detected — supplemental root CA will be "
+                    f"added to managed bundles alongside {self.provider['short_name']}"
+                )
+
+    def _all_proxy_root_paths(self):
+        """Return the on-disk paths of every CA root that bundles must contain.
+
+        Always begins with the primary provider cert, followed by any
+        materialized supplemental roots. When no supplemental roots are active
+        this is exactly [self.cert_path], preserving original behavior.
+        """
+        paths = [self.cert_path]
+        paths.extend(e['path'] for e in self.extra_roots if e.get('path'))
+        return paths
+
+    def _append_all_proxy_roots(self, target_file):
+        """Append every proxy root (primary + supplemental) to target_file.
+
+        Each append is individually idempotent via safe_append_certificate.
+        Returns True only if every root was appended (or already present).
+        """
+        ok = True
+        for path in self._all_proxy_root_paths():
+            if not self.safe_append_certificate(path, target_file):
+                ok = False
+        return ok
+
+    def _all_roots_present_in_file(self, target_file, likely=False):
+        """Return True only if every proxy root is already present in target_file.
+
+        With likely=True, uses the faster pure-Python matcher. When no
+        supplemental roots are active this reduces to a single primary-cert
+        check, preserving original behavior.
+        """
+        matcher = (self.certificate_likely_exists_in_file if likely
+                   else self.certificate_exists_in_file)
+        return all(
+            matcher(path, target_file)
+            for path in self._all_proxy_root_paths()
+        )
+
+    def _status_roots_present(self, primary_cert_path, target_file, likely=False):
+        """Status-mode 'all roots present' check.
+
+        Uses the supplied primary certificate path (typically a temp file, since
+        the primary may not be saved to cert_path during a status check) plus
+        every materialized supplemental root. When no supplemental roots are
+        active this reduces to the single primary check, preserving behavior.
+        """
+        matcher = (self.certificate_likely_exists_in_file if likely
+                   else self.certificate_exists_in_file)
+        if not matcher(primary_cert_path, target_file):
+            return False
+        for entry in self.extra_roots:
+            if entry.get('path') and not matcher(entry['path'], target_file):
+                return False
+        return True
+
+    def _all_root_aliases(self):
+        """Return (keytool_alias, cert_path) for the primary and each supplemental root."""
+        pairs = [(self.provider['keytool_alias'], self.cert_path)]
+        pairs.extend(
+            (e['keytool_alias'], e['path']) for e in self.extra_roots if e.get('path')
+        )
+        return pairs
+
+    def _keytool_alias_present(self, keytool_bin, keystore, alias):
+        """Return True if alias is already present in the Java keystore."""
+        try:
+            result = subprocess.run(
+                [keytool_bin, '-list', '-alias', alias,
+                 '-keystore', keystore, '-storepass', 'changeit'],
+                capture_output=True
+            )
+            return result.returncode == 0 and alias in result.stdout.decode()
+        except Exception:
+            return False
+
+    def _ensure_roots_in_keystore(self, keytool_bin, keystore, label):
+        """Import every proxy root (primary + supplemental) into a Java keystore.
+
+        Each root is imported under its own alias and skipped when already
+        present. Returns 'already_ok', 'configured', or 'failed' for the
+        keystore as a whole. With no supplemental roots active this is
+        equivalent to the original single-alias check-then-import.
+        """
+        imported = False
+        failed = False
+        for alias, cert_path in self._all_root_aliases():
+            if self._keytool_alias_present(keytool_bin, keystore, alias):
+                continue
+            if not self.is_install_mode():
+                self.print_action(f"    Would import {alias} certificate to: {keystore}")
+                imported = True
+                continue
+            result = subprocess.run(
+                [keytool_bin, '-import', '-trustcacerts', '-alias', alias,
+                 '-file', cert_path, '-keystore', keystore, '-storepass', 'changeit',
+                 '-noprompt'],
+                capture_output=True, text=True
+            )
+            if result.returncode == 0:
+                self.print_info(f"    ✓ {label}: {alias} added successfully")
+                imported = True
+            else:
+                self.print_warn(f"    ✗ {label}: Failed to add {alias} (may require sudo)")
+                self.print_info("      Fix with:")
+                print(f"        sudo {keytool_bin} -import -trustcacerts \\")
+                print(f"          -alias {alias} \\")
+                print(f"          -file {cert_path} \\")
+                print(f"          -keystore {keystore} \\")
+                print("          -storepass changeit -noprompt")
+                if result.stdout:
+                    self.print_warn(f"      Keytool response: {result.stdout}")
+                failed = True
+        if failed and not imported:
+            return 'failed'
+        if imported:
+            return 'configured'
+        return 'already_ok'
+
+    def _all_container_certs(self):
+        """Return (container_cert_name, cert_path) for the primary and each supplemental root."""
+        pairs = [(self.provider['container_cert_name'], self.cert_path)]
+        pairs.extend(
+            (e['container_cert_name'], e['path']) for e in self.extra_roots if e.get('path')
+        )
+        return pairs
+
+    def _container_certs_present(self, docker_certs_dir):
+        """Return True if every proxy root is present in ~/.docker/certs.d."""
+        for name, cert_path in self._all_container_certs():
+            dest = os.path.join(docker_certs_dir, f"{name}.crt")
+            if not (os.path.exists(dest)
+                    and self.certificate_likely_exists_in_file(cert_path, dest)):
+                return False
+        return True
+
+    def _install_container_certs(self, docker_certs_dir):
+        """Copy every proxy root into ~/.docker/certs.d as {name}.crt."""
+        self._safe_makedirs(docker_certs_dir)
+        for name, cert_path in self._all_container_certs():
+            dest = os.path.join(docker_certs_dir, f"{name}.crt")
+            shutil.copy(cert_path, dest)
+            self._fix_ownership(dest)
+            self.print_info(f"Certificate installed to {dest}")
+
     def _get_brew_prefix(self):
         """Return the Homebrew prefix directory.
 
@@ -2258,7 +2684,7 @@ class FumitmPython:
                     return ToolResult('brew-cacerts', 'failed', 'brew postinstall ca-certificates failed')
             return ToolResult('brew-cacerts', 'skipped', 'Dry run')
 
-        if self.certificate_exists_in_file(self.cert_path, bundle_path):
+        if self._all_roots_present_in_file(bundle_path):
             self.print_debug(
                 "Proxy certificate already in Homebrew CA bundle"
             )
@@ -2329,11 +2755,12 @@ class FumitmPython:
                     self._safe_makedirs(os.path.dirname(node_bundle))
                     shutil.copy(self.cert_path, node_bundle)
                     self._fix_ownership(node_bundle)
+                    self._append_all_proxy_roots(node_bundle)
                     self.add_to_shell_config("NODE_EXTRA_CA_CERTS", node_bundle, shell_config)
                     self.print_info(f"Migrated Node.js CA bundle to {node_bundle}")
             elif os.path.exists(node_extra_ca_certs):
                 # Check if the file contains our certificate using normalized comparison
-                if self.certificate_exists_in_file(self.cert_path, node_extra_ca_certs):
+                if self._all_roots_present_in_file(node_extra_ca_certs):
                     # Certificate already exists in NODE_EXTRA_CA_CERTS, skip to npm setup
                     pass
                 else:
@@ -2364,7 +2791,7 @@ class FumitmPython:
                                         Path(new_path).touch()
                                         self._fix_ownership(new_path)
 
-                                self.safe_append_certificate(self.cert_path, new_path)
+                                self._append_all_proxy_roots(new_path)
 
                                 self.add_to_shell_config("NODE_EXTRA_CA_CERTS", new_path, shell_config)
                                 self.print_info(f"Created new certificate bundle at {new_path}")
@@ -2375,7 +2802,7 @@ class FumitmPython:
                             self.print_action(f"Would append proxy certificate to {node_extra_ca_certs}")
                         else:
                             self.print_info(f"Appending proxy certificate to {node_extra_ca_certs}")
-                            self.safe_append_certificate(self.cert_path, node_extra_ca_certs)
+                            self._append_all_proxy_roots(node_extra_ca_certs)
             else:
                 self.print_info("Configuring Node.js certificate...")
                 self.print_warn(f"NODE_EXTRA_CA_CERTS points to a non-existent file: {node_extra_ca_certs}")
@@ -2395,10 +2822,11 @@ class FumitmPython:
                 self.print_info(f"Creating Node.js CA bundle at {node_bundle}")
                 self._safe_makedirs(os.path.dirname(node_bundle))
                 
-                # Start with just the proxy certificate
+                # Start with just the proxy certificates
                 # (NODE_EXTRA_CA_CERTS supplements system certs, doesn't replace them)
                 shutil.copy(self.cert_path, node_bundle)
                 self._fix_ownership(node_bundle)
+                self._append_all_proxy_roots(node_bundle)
 
                 self.add_to_shell_config("NODE_EXTRA_CA_CERTS", node_bundle, shell_config)
                 self.print_info("Created Node.js CA bundle with proxy certificate")
@@ -2444,7 +2872,7 @@ class FumitmPython:
                 else:
                     self._safe_makedirs(os.path.dirname(npm_bundle))
                     self.create_bundle_with_system_certs(npm_bundle)
-                    self.safe_append_certificate(self.cert_path, npm_bundle)
+                    self._append_all_proxy_roots(npm_bundle)
                     subprocess.run(['npm', 'config', 'set', 'cafile', npm_bundle])
                     self.print_info(f"Migrated npm cafile to: {npm_bundle}")
                 return
@@ -2461,13 +2889,13 @@ class FumitmPython:
                     else:
                         self._safe_makedirs(os.path.dirname(npm_bundle))
                         self.create_bundle_with_system_certs(npm_bundle)
-                        self.safe_append_certificate(self.cert_path, npm_bundle)
+                        self._append_all_proxy_roots(npm_bundle)
                         subprocess.run(['npm', 'config', 'set', 'cafile', npm_bundle])
                         self.print_info(f"Repointed npm cafile to managed bundle: {npm_bundle}")
                     return
 
                 # Check if the file contains our certificate using normalized comparison
-                if not self.certificate_exists_in_file(self.cert_path, current_cafile):
+                if not self._all_roots_present_in_file(current_cafile):
                     self.print_info("Configuring npm certificate...")
                     self.print_warn("Current npm cafile doesn't contain proxy certificate")
                     
@@ -2490,7 +2918,7 @@ class FumitmPython:
                                     self._fix_ownership(npm_bundle)
 
                             # Append certificate to bundle
-                            self.safe_append_certificate(self.cert_path, npm_bundle)
+                            self._append_all_proxy_roots(npm_bundle)
 
                             subprocess.run(['npm', 'config', 'set', 'cafile', npm_bundle])
                             self.print_info(f"Created new npm cafile at {npm_bundle}")
@@ -2501,7 +2929,7 @@ class FumitmPython:
                             response = self._prompt("Do you want to append it to the existing cafile? (y/N) ")
                             if response.lower() == 'y':
                                 self.print_info(f"Appending proxy certificate to {current_cafile}")
-                                self.safe_append_certificate(self.cert_path, current_cafile)
+                                self._append_all_proxy_roots(current_cafile)
             else:
                 self.print_info("Configuring npm certificate...")
                 self.print_warn(f"npm cafile points to non-existent file: {current_cafile}")
@@ -2514,7 +2942,7 @@ class FumitmPython:
                     if response.lower() != 'n':
                         self._safe_makedirs(os.path.dirname(npm_bundle))
                         self.create_bundle_with_system_certs(npm_bundle)
-                        self.safe_append_certificate(self.cert_path, npm_bundle)
+                        self._append_all_proxy_roots(npm_bundle)
                         subprocess.run(['npm', 'config', 'set', 'cafile', npm_bundle])
                         self.print_info(f"Created and configured npm cafile at {npm_bundle}")
         else:
@@ -2530,7 +2958,7 @@ class FumitmPython:
                     self._safe_makedirs(os.path.dirname(npm_bundle))
                     if not self.create_bundle_with_system_certs(npm_bundle):
                         self.print_warn("Could not find system CA bundle, creating new bundle with only proxy certificate")
-                    self.safe_append_certificate(self.cert_path, npm_bundle)
+                    self._append_all_proxy_roots(npm_bundle)
                     subprocess.run(['npm', 'config', 'set', 'cafile', npm_bundle])
                     self.print_info(f"Configured npm cafile to: {npm_bundle}")
                     
@@ -2588,7 +3016,7 @@ class FumitmPython:
                 return  # Points to fumitm-managed bundle, that's OK
 
             # Check if file exists and contains WARP cert
-            if os.path.exists(current_cafile) and self.certificate_exists_in_file(self.cert_path, current_cafile):
+            if os.path.exists(current_cafile) and self._all_roots_present_in_file(current_cafile):
                 return  # Working config, leave it
 
             # Problematic config - delete it
@@ -2631,7 +3059,7 @@ class FumitmPython:
                 return  # Points to fumitm-managed bundle, that's OK
 
             # Check if file exists and contains WARP cert
-            if os.path.exists(current_cafile) and self.certificate_exists_in_file(self.cert_path, current_cafile):
+            if os.path.exists(current_cafile) and self._all_roots_present_in_file(current_cafile):
                 return  # Working config, leave it
 
             # Problematic config - delete it
@@ -2699,7 +3127,7 @@ class FumitmPython:
                                     self._fix_ownership(new_path)
 
                             # Append certificate to the new path
-                            self.safe_append_certificate(self.cert_path, new_path)
+                            self._append_all_proxy_roots(new_path)
 
                             needs_setup = True
                             self.print_info("Configuring Python certificate...")
@@ -2723,7 +3151,7 @@ class FumitmPython:
                             return ToolResult('python', 'skipped', 'Dry run')
                         else:
                             self.create_bundle_with_system_certs(python_bundle)
-                            self.safe_append_certificate(self.cert_path, python_bundle)
+                            self._append_all_proxy_roots(python_bundle)
                             self.add_to_shell_config("REQUESTS_CA_BUNDLE", python_bundle, shell_config)
                             self.add_to_shell_config("SSL_CERT_FILE", python_bundle, shell_config)
                             self.add_to_shell_config("CURL_CA_BUNDLE", python_bundle, shell_config)
@@ -2731,7 +3159,7 @@ class FumitmPython:
                             return ToolResult('python', 'configured', 'Repointed suspicious REQUESTS_CA_BUNDLE')
 
                     # Check if the file contains our certificate using normalized comparison
-                    if not self.certificate_exists_in_file(self.cert_path, requests_ca_bundle):
+                    if not self._all_roots_present_in_file(requests_ca_bundle):
                         needs_setup = True
                         self.print_info("Configuring Python certificate...")
                         self.print_info(f"REQUESTS_CA_BUNDLE is already set to: {requests_ca_bundle}")
@@ -2740,7 +3168,7 @@ class FumitmPython:
                             self.print_action(f"Would append proxy certificate to {requests_ca_bundle}")
                         else:
                             self.print_info(f"Appending proxy certificate to {requests_ca_bundle}")
-                            self.safe_append_certificate(self.cert_path, requests_ca_bundle)
+                            self._append_all_proxy_roots(requests_ca_bundle)
                     else:
                         # REQUESTS_CA_BUNDLE is healthy — ensure SSL_CERT_FILE is also set,
                         # since tools like httpx and Python's ssl module use it independently.
@@ -2769,7 +3197,7 @@ class FumitmPython:
                 self.print_info(f"Creating Python CA bundle at {python_bundle}")
                 if not self.create_bundle_with_system_certs(python_bundle):
                     self.print_warn("Could not find system CA bundle, creating new bundle")
-                self.safe_append_certificate(self.cert_path, python_bundle)
+                self._append_all_proxy_roots(python_bundle)
 
             self.add_to_shell_config("REQUESTS_CA_BUNDLE", python_bundle, shell_config)
             self.add_to_shell_config("SSL_CERT_FILE", python_bundle, shell_config)
@@ -2791,10 +3219,10 @@ class FumitmPython:
                         # Ensure the managed bundle exists
                         if not os.path.exists(python_bundle):
                             self.create_bundle_with_system_certs(python_bundle)
-                            self.safe_append_certificate(self.cert_path, python_bundle)
+                            self._append_all_proxy_roots(python_bundle)
                         self.add_to_shell_config("SSL_CERT_FILE", python_bundle, shell_config)
                         self.print_info(f"Repointed SSL_CERT_FILE to managed bundle: {python_bundle}")
-                elif not self.certificate_exists_in_file(self.cert_path, ssl_cert_file):
+                elif not self._all_roots_present_in_file(ssl_cert_file):
                     needs_setup = True
                     self.print_info("Configuring SSL_CERT_FILE...")
                     self.print_warn("SSL_CERT_FILE doesn't contain proxy certificate")
@@ -2803,7 +3231,7 @@ class FumitmPython:
                     else:
                         if not os.path.exists(python_bundle):
                             self.create_bundle_with_system_certs(python_bundle)
-                            self.safe_append_certificate(self.cert_path, python_bundle)
+                            self._append_all_proxy_roots(python_bundle)
                         self.add_to_shell_config("SSL_CERT_FILE", python_bundle, shell_config)
                         self.print_info(f"Repointed SSL_CERT_FILE to managed bundle: {python_bundle}")
             else:
@@ -2815,7 +3243,7 @@ class FumitmPython:
                 else:
                     if not os.path.exists(python_bundle):
                         self.create_bundle_with_system_certs(python_bundle)
-                        self.safe_append_certificate(self.cert_path, python_bundle)
+                        self._append_all_proxy_roots(python_bundle)
                     self.add_to_shell_config("SSL_CERT_FILE", python_bundle, shell_config)
                     self.print_info(f"Repointed SSL_CERT_FILE to managed bundle: {python_bundle}")
 
@@ -2849,7 +3277,7 @@ class FumitmPython:
                         if current_value == ca_bundle:
                             return False
                         if os.path.exists(current_value) and \
-                                self.certificate_exists_in_file(self.cert_path, current_value):
+                                self._all_roots_present_in_file(current_value):
                             return False
                 # Existing value is stale or wrong — replace it
                 lines = content.splitlines()
@@ -2972,14 +3400,14 @@ class FumitmPython:
                 else:
                     self._safe_makedirs(gcloud_cert_dir)
                     self.create_bundle_with_system_certs(gcloud_bundle)
-                    self.safe_append_certificate(self.cert_path, gcloud_bundle)
+                    self._append_all_proxy_roots(gcloud_bundle)
                     subprocess.run(['gcloud', 'config', 'set', 'core/custom_ca_certs_file', gcloud_bundle], capture_output=True, timeout=30)
                     self.print_info(f"Repointed gcloud custom CA file to managed bundle: {gcloud_bundle}")
                     return ToolResult('gcloud', 'configured', 'Repointed suspicious gcloud CA file')
                 return ToolResult('gcloud', 'skipped', 'Dry run')
 
             # Check if current CA file contains our certificate using normalized comparison
-            if not self.certificate_exists_in_file(self.cert_path, current_ca_file):
+            if not self._all_roots_present_in_file(current_ca_file):
                 needs_setup = True
         else:
             needs_setup = True
@@ -3022,7 +3450,7 @@ class FumitmPython:
             # Create combined bundle
             self.print_info(f"Creating gcloud CA bundle at {gcloud_bundle}")
             self.create_bundle_with_system_certs(gcloud_bundle)
-            self.safe_append_certificate(self.cert_path, gcloud_bundle)
+            self._append_all_proxy_roots(gcloud_bundle)
 
             # Configure gcloud
             result = subprocess.run(
@@ -3101,7 +3529,7 @@ class FumitmPython:
         # Build full bundle and configure
         self._safe_makedirs(os.path.dirname(git_bundle))
         self.create_bundle_with_system_certs(git_bundle)
-        self.safe_append_certificate(self.cert_path, git_bundle)
+        self._append_all_proxy_roots(git_bundle)
         subprocess.run(['git', 'config', '--global', 'http.sslCAInfo', git_bundle], capture_output=True, text=True)
         self.print_info(f"Configured git http.sslCAInfo to: {git_bundle}")
         return ToolResult('git', 'configured', f'Set http.sslCAInfo to {git_bundle}')
@@ -3171,7 +3599,7 @@ class FumitmPython:
         # Create the bundle and configure
         self._safe_makedirs(os.path.dirname(curl_bundle))
         self.create_bundle_with_system_certs(curl_bundle)
-        self.safe_append_certificate(self.cert_path, curl_bundle)
+        self._append_all_proxy_roots(curl_bundle)
         shell_type = self.detect_shell()
         shell_config = self.get_shell_config(shell_type)
         self.add_to_shell_config("CURL_CA_BUNDLE", curl_bundle, shell_config)
@@ -3218,7 +3646,7 @@ class FumitmPython:
                         self.print_action(f"Would create AWS CA bundle at {aws_bundle}")
                         self.print_action(f"Would repoint AWS_CA_BUNDLE to {aws_bundle}")
                         return ToolResult('aws', 'skipped', 'Dry run')
-                elif not self.certificate_likely_exists_in_file(self.cert_path, aws_env):
+                elif not self._all_roots_present_in_file(aws_env, likely=True):
                     # Bundle exists and looks OK but doesn't contain our proxy cert
                     self.print_info("Configuring AWS CLI certificate bundle...")
                     self.print_info(f"AWS_CA_BUNDLE bundle is missing the {self.provider['name']} proxy certificate")
@@ -3248,7 +3676,7 @@ class FumitmPython:
         # Create the bundle and configure
         self._safe_makedirs(os.path.dirname(aws_bundle))
         self.create_bundle_with_system_certs(aws_bundle)
-        self.safe_append_certificate(self.cert_path, aws_bundle)
+        self._append_all_proxy_roots(aws_bundle)
         shell_type = self.detect_shell()
         shell_config = self.get_shell_config(shell_type)
         self.add_to_shell_config("AWS_CA_BUNDLE", aws_bundle, shell_config)
@@ -3482,42 +3910,14 @@ class FumitmPython:
                 failed_count += 1
                 continue
 
-            # Check if certificate already exists
-            try:
-                result = subprocess.run(
-                    ['keytool', '-list', '-alias', self.provider['keytool_alias'],
-                     '-keystore', cacerts, '-storepass', 'changeit'],
-                    capture_output=True
-                )
-                if result.returncode == 0 and self.provider['keytool_alias'] in result.stdout.decode():
-                    self.print_info(f"  ✓ {version_name}: Certificate already installed")
-                    already_ok_count += 1
-                    continue
-            except Exception:
-                pass
-
-            self.print_info(f"  Configuring {version_name}...")
-
-            if not self.is_install_mode():
-                self.print_action(f"    Would import certificate to: {cacerts}")
+            status = self._ensure_roots_in_keystore('keytool', cacerts, version_name)
+            if status == 'already_ok':
+                self.print_info(f"  ✓ {version_name}: Certificate already installed")
+                already_ok_count += 1
+            elif status == 'configured':
+                configured_count += 1
             else:
-                result = subprocess.run(
-                    ['keytool', '-import', '-trustcacerts', '-alias', self.provider['keytool_alias'],
-                     '-file', self.cert_path, '-keystore', cacerts, '-storepass', 'changeit', '-noprompt'],
-                    capture_output=True
-                )
-                if result.returncode == 0:
-                    self.print_info(f"    ✓ {version_name}: Certificate added successfully")
-                    configured_count += 1
-                else:
-                    self.print_warn(f"    ✗ {version_name}: Failed to add certificate (may require sudo)")
-                    self.print_info( "      Fix with:")
-                    print(f"        sudo keytool -import -trustcacerts \\")
-                    print(f"          -alias {self.provider['keytool_alias']} \\")
-                    print(f"          -file {self.cert_path} \\")
-                    print(f"          -keystore {cacerts} \\")
-                    print( "          -storepass changeit -noprompt")
-                    failed_count += 1
+                failed_count += 1
 
         total = len(java_homes)
         if failed_count > 0 and configured_count == 0 and already_ok_count == 0:
@@ -3561,46 +3961,14 @@ class FumitmPython:
                 failed_count += 1
                 continue
 
-            # Check if certificate already exists
-            try:
-                result = subprocess.run(
-                    ['keytool', '-list', '-alias', self.provider['keytool_alias'],
-                     '-keystore', cacerts, '-storepass', 'changeit'],
-                    capture_output=True
-                )
-                if result.returncode == 0 and self.provider['keytool_alias'] in result.stdout.decode():
-                    # Certificate already exists
-                    self.print_info(f"  ✓ {version_name}: Certificate already installed")
-                    already_ok_count += 1
-                    continue
-            except Exception:
-                pass
-
-            self.print_info(f"  Installing certificate for {version_name}...")
-
-            if not self.is_install_mode():
-                self.print_action(f"    Would import certificate to: {cacerts}")
+            status = self._ensure_roots_in_keystore('keytool', cacerts, version_name)
+            if status == 'already_ok':
+                self.print_info(f"  ✓ {version_name}: Certificate already installed")
+                already_ok_count += 1
+            elif status == 'configured':
+                configured_count += 1
             else:
-                result = subprocess.run(
-                    ['keytool', '-import', '-trustcacerts', '-alias', self.provider['keytool_alias'],
-                     '-file', self.cert_path, '-keystore', cacerts, '-storepass', 'changeit', '-noprompt'],
-                    capture_output=True,
-                    text=True
-                )
-                if result.returncode == 0:
-                    self.print_info(f"    ✓ {version_name}: Certificate added successfully")
-                    configured_count += 1
-                else:
-                    self.print_warn(f"    ✗ {version_name}: Failed to add certificate (may require sudo)")
-                    self.print_info( "      Fix with:")
-                    print(f"        sudo keytool -import -trustcacerts \\")
-                    print(f"          -alias {self.provider['keytool_alias']} \\")
-                    print(f"          -file {self.cert_path} \\")
-                    print(f"          -keystore {cacerts} \\")
-                    print( "          -storepass changeit -noprompt")
-                    if len(result.stdout) > 0:
-                        self.print_warn(f"      Keytool response: {result.stdout}")
-                    failed_count += 1
+                failed_count += 1
 
         total = len(java_homes)
         if failed_count > 0 and configured_count == 0 and already_ok_count == 0:
@@ -3657,46 +4025,15 @@ class FumitmPython:
             self.print_error(f"DBeaver cacerts file not found at: {dbeaver_cacerts}")
             return ToolResult('dbeaver', 'failed', 'DBeaver cacerts file not found')
 
-        # Check if certificate already exists
-        try:
-            result = subprocess.run(
-                [dbeaver_keytool, '-list', '-alias', self.provider['keytool_alias'],
-                 '-keystore', dbeaver_cacerts, '-storepass', 'changeit'],
-                capture_output=True
-            )
-            if result.returncode == 0 and self.provider['keytool_alias'] in result.stdout.decode():
-                # Certificate already exists, nothing to do
-                return ToolResult('dbeaver', 'already_ok', 'Certificate already installed')
-        except Exception:
-            pass
-
         self.print_info("Configuring DBeaver certificate...")
         self.print_info("Found DBeaver at default install location")
 
-        if not self.is_install_mode():
-            self.print_action(f"Would import certificate to DBeaver keystore: {dbeaver_cacerts}")
-            self.print_action(f"Would run: {dbeaver_keytool} -import -trustcacerts -alias {self.provider['keytool_alias']} -file {self.cert_path} -keystore {dbeaver_cacerts} -storepass changeit -noprompt")
-        else:
-            self.print_info("Adding certificate to DBeaver keystore...")
-            result = subprocess.run(
-                [dbeaver_keytool, '-import', '-trustcacerts', '-alias', self.provider['keytool_alias'],
-                 '-file', self.cert_path, '-keystore', dbeaver_cacerts, '-storepass', 'changeit', '-noprompt'],
-                capture_output=True
-            )
-            if result.returncode == 0:
-                self.print_info("Certificate added to DBeaver keystore successfully")
-                return ToolResult('dbeaver', 'configured', 'Certificate added to DBeaver keystore')
-            else:
-                self.print_warn("Failed to add certificate to DBeaver keystore (may require sudo)")
-                self.print_info( "      Fix with:")
-                print(f"        sudo {dbeaver_keytool} -import -trustcacerts \\")
-                print(f"          -alias {self.provider['keytool_alias']} \\")
-                print(f"          -file {self.cert_path} \\")
-                print(f"          -keystore {dbeaver_cacerts} \\")
-                print( "          -storepass changeit -noprompt")
-                if len(result.stdout) > 0:
-                    self.print_warn(f"Keytool response: {result.stdout.decode('utf-8')}")
-                return ToolResult('dbeaver', 'failed', 'Failed to add certificate (may require sudo)')
+        status = self._ensure_roots_in_keystore(dbeaver_keytool, dbeaver_cacerts, 'DBeaver')
+        if status == 'already_ok':
+            return ToolResult('dbeaver', 'already_ok', 'Certificate already installed')
+        if status == 'configured':
+            return ToolResult('dbeaver', 'configured', 'Certificate added to DBeaver keystore')
+        return ToolResult('dbeaver', 'failed', 'Failed to add certificate (may require sudo)')
     
     def setup_wget_cert(self):
         """Setup wget certificate."""
@@ -3784,6 +4121,21 @@ class FumitmPython:
         except Exception:
             return False
 
+    def _check_cert_in_podman_vm(self):
+        """Return True if every proxy root is present in the Podman VM."""
+        try:
+            for cert_name, _ in self._all_container_certs():
+                result = subprocess.run(
+                    ['podman', 'machine', 'ssh',
+                     f'test -f /etc/pki/ca-trust/source/anchors/{cert_name}.pem'],
+                    capture_output=True
+                )
+                if result.returncode != 0:
+                    return False
+            return True
+        except Exception:
+            return False
+
     def _install_cert_via_podman_ssh(self):
         """Install cert into Podman VM via podman machine ssh.
 
@@ -3793,18 +4145,17 @@ class FumitmPython:
         Returns:
             tuple: (success: bool, message: str)
         """
-        cert_name = self.provider['container_cert_name']
         try:
-            with open(self.cert_path, 'r') as f:
-                cert_content = f.read()
-
-            result = subprocess.run(
-                ['podman', 'machine', 'ssh',
-                 f'sudo tee /etc/pki/ca-trust/source/anchors/{cert_name}.pem'],
-                input=cert_content, text=True, capture_output=True
-            )
-            if result.returncode != 0:
-                return False, 'Failed to copy certificate into VM'
+            for cert_name, cert_path in self._all_container_certs():
+                with open(cert_path, 'r') as f:
+                    cert_content = f.read()
+                result = subprocess.run(
+                    ['podman', 'machine', 'ssh',
+                     f'sudo tee /etc/pki/ca-trust/source/anchors/{cert_name}.pem'],
+                    input=cert_content, text=True, capture_output=True
+                )
+                if result.returncode != 0:
+                    return False, 'Failed to copy certificate into VM'
 
             result = subprocess.run(
                 ['podman', 'machine', 'ssh', 'sudo update-ca-trust'],
@@ -3830,21 +4181,13 @@ class FumitmPython:
         docker_certs_dir = os.path.expanduser("~/.docker/certs.d")
         cert_dest = os.path.join(docker_certs_dir, f"{self.provider['container_cert_name']}.crt")
 
-        persistent_installed = (
-            os.path.exists(cert_dest)
-            and self.certificate_likely_exists_in_file(self.cert_path, cert_dest)
-        )
+        persistent_installed = self._container_certs_present(docker_certs_dir)
 
         vm_is_running = self._podman_vm_running()
         vm_needs_cert = False
         if vm_is_running:
             try:
-                result = subprocess.run(
-                    ['podman', 'machine', 'ssh',
-                     f'test -f /etc/pki/ca-trust/source/anchors/{self.provider["container_cert_name"]}.pem'],
-                    capture_output=True
-                )
-                vm_needs_cert = result.returncode != 0
+                vm_needs_cert = not self._check_cert_in_podman_vm()
             except Exception:
                 pass
 
@@ -3864,10 +4207,7 @@ class FumitmPython:
             vm_failed = False
 
             if not persistent_installed:
-                self._safe_makedirs(docker_certs_dir)
-                shutil.copy(self.cert_path, cert_dest)
-                self._fix_ownership(cert_dest)
-                self.print_info(f"Certificate installed to {cert_dest}")
+                self._install_container_certs(docker_certs_dir)
                 persistent_changed = True
 
             if vm_is_running and vm_needs_cert:
@@ -3894,14 +4234,16 @@ class FumitmPython:
     
     def _check_cert_in_rancher_vm(self):
         """Check whether the CA cert exists in the Rancher Desktop VM."""
-        cert_name = self.provider['container_cert_name']
         try:
-            result = subprocess.run(
-                ['rdctl', 'shell', 'test', '-f',
-                 f'/usr/local/share/ca-certificates/{cert_name}.crt'],
-                capture_output=True
-            )
-            return result.returncode == 0
+            for cert_name, _ in self._all_container_certs():
+                result = subprocess.run(
+                    ['rdctl', 'shell', 'test', '-f',
+                     f'/usr/local/share/ca-certificates/{cert_name}.crt'],
+                    capture_output=True
+                )
+                if result.returncode != 0:
+                    return False
+            return True
         except Exception:
             return False
 
@@ -3911,18 +4253,17 @@ class FumitmPython:
         Returns:
             tuple: (success: bool, message: str)
         """
-        cert_name = self.provider['container_cert_name']
         try:
-            with open(self.cert_path, 'r') as f:
-                cert_content = f.read()
-
-            result = subprocess.run(
-                ['rdctl', 'shell', 'sudo', 'tee',
-                 f'/usr/local/share/ca-certificates/{cert_name}.crt'],
-                input=cert_content, text=True, capture_output=True
-            )
-            if result.returncode != 0:
-                return False, 'Failed to copy certificate into VM'
+            for cert_name, cert_path in self._all_container_certs():
+                with open(cert_path, 'r') as f:
+                    cert_content = f.read()
+                result = subprocess.run(
+                    ['rdctl', 'shell', 'sudo', 'tee',
+                     f'/usr/local/share/ca-certificates/{cert_name}.crt'],
+                    input=cert_content, text=True, capture_output=True
+                )
+                if result.returncode != 0:
+                    return False, 'Failed to copy certificate into VM'
 
             result = subprocess.run(
                 ['rdctl', 'shell', 'sudo', 'update-ca-certificates'],
@@ -3946,10 +4287,7 @@ class FumitmPython:
         docker_certs_dir = os.path.expanduser("~/.docker/certs.d")
         cert_dest = os.path.join(docker_certs_dir, f"{self.provider['container_cert_name']}.crt")
 
-        persistent_installed = (
-            os.path.exists(cert_dest)
-            and self.certificate_likely_exists_in_file(self.cert_path, cert_dest)
-        )
+        persistent_installed = self._container_certs_present(docker_certs_dir)
 
         vm_is_running = False
         vm_needs_cert = False
@@ -3977,10 +4315,7 @@ class FumitmPython:
             vm_failed = False
 
             if not persistent_installed:
-                self._safe_makedirs(docker_certs_dir)
-                shutil.copy(self.cert_path, cert_dest)
-                self._fix_ownership(cert_dest)
-                self.print_info(f"Certificate installed to {cert_dest}")
+                self._install_container_certs(docker_certs_dir)
                 persistent_changed = True
 
             if vm_is_running and vm_needs_cert:
@@ -4056,17 +4391,20 @@ class FumitmPython:
                     self.print_info("Make sure emulator was started with -writable-system flag")
                     return ToolResult('android', 'failed', 'Failed to remount system partition')
 
-                # Push certificate
-                result = subprocess.run(
-                    ['adb', 'push', self.cert_path, f'/system/etc/security/cacerts/{self.provider["container_cert_name"]}.pem'],
-                    capture_output=True
-                )
-                if result.returncode == 0:
-                    # Set permissions
-                    subprocess.run(
-                        ['adb', 'shell', 'chmod', '644', f'/system/etc/security/cacerts/{self.provider["container_cert_name"]}.pem'],
-                        capture_output=True
+                # Push each proxy root (primary + supplemental) into the emulator
+                push_failed = False
+                for cert_name, cert_path in self._all_container_certs():
+                    dest = f'/system/etc/security/cacerts/{cert_name}.pem'
+                    result = subprocess.run(
+                        ['adb', 'push', cert_path, dest], capture_output=True
                     )
+                    if result.returncode != 0:
+                        push_failed = True
+                        break
+                    subprocess.run(
+                        ['adb', 'shell', 'chmod', '644', dest], capture_output=True
+                    )
+                if not push_failed:
                     self.print_info("Certificate installed. Rebooting emulator...")
                     subprocess.run(['adb', 'reboot'], capture_output=True)
                     self.print_info("Android emulator certificate installed successfully")
@@ -4079,14 +4417,16 @@ class FumitmPython:
     
     def _check_cert_in_colima_vm(self):
         """Check whether the CA cert exists in the Colima VM."""
-        cert_name = self.provider['container_cert_name']
         try:
-            result = subprocess.run(
-                ['colima', 'ssh', '--', 'test', '-f',
-                 f'/usr/local/share/ca-certificates/{cert_name}.crt'],
-                capture_output=True
-            )
-            return result.returncode == 0
+            for cert_name, _ in self._all_container_certs():
+                result = subprocess.run(
+                    ['colima', 'ssh', '--', 'test', '-f',
+                     f'/usr/local/share/ca-certificates/{cert_name}.crt'],
+                    capture_output=True
+                )
+                if result.returncode != 0:
+                    return False
+            return True
         except Exception:
             return False
 
@@ -4096,18 +4436,17 @@ class FumitmPython:
         Returns:
             tuple: (success: bool, message: str)
         """
-        cert_name = self.provider['container_cert_name']
         try:
-            with open(self.cert_path, 'r') as f:
-                cert_content = f.read()
-
-            result = subprocess.run(
-                ['colima', 'ssh', '--', 'sudo', 'tee',
-                 f'/usr/local/share/ca-certificates/{cert_name}.crt'],
-                input=cert_content, text=True, capture_output=True
-            )
-            if result.returncode != 0:
-                return False, 'Failed to copy certificate into VM'
+            for cert_name, cert_path in self._all_container_certs():
+                with open(cert_path, 'r') as f:
+                    cert_content = f.read()
+                result = subprocess.run(
+                    ['colima', 'ssh', '--', 'sudo', 'tee',
+                     f'/usr/local/share/ca-certificates/{cert_name}.crt'],
+                    input=cert_content, text=True, capture_output=True
+                )
+                if result.returncode != 0:
+                    return False, 'Failed to copy certificate into VM'
 
             result = subprocess.run(
                 ['colima', 'ssh', '--', 'sudo', 'update-ca-certificates'],
@@ -4132,10 +4471,7 @@ class FumitmPython:
         docker_certs_dir = os.path.expanduser("~/.docker/certs.d")
         cert_dest = os.path.join(docker_certs_dir, f"{self.provider['container_cert_name']}.crt")
 
-        persistent_installed = (
-            os.path.exists(cert_dest)
-            and self.certificate_likely_exists_in_file(self.cert_path, cert_dest)
-        )
+        persistent_installed = self._container_certs_present(docker_certs_dir)
 
         vm_is_running = False
         vm_needs_cert = False
@@ -4163,10 +4499,7 @@ class FumitmPython:
             vm_failed = False
 
             if not persistent_installed:
-                self._safe_makedirs(docker_certs_dir)
-                shutil.copy(self.cert_path, cert_dest)
-                self._fix_ownership(cert_dest)
-                self.print_info(f"Certificate installed to {cert_dest}")
+                self._install_container_certs(docker_certs_dir)
                 persistent_changed = True
 
             if vm_is_running and vm_needs_cert:
@@ -4272,16 +4605,16 @@ class FumitmPython:
         Uses nsenter via a locally cached container image to probe the VM's
         filesystem. Checks both Debian-style and Fedora-style cert paths.
         """
-        cert_name = self.provider['container_cert_name']
-        check_script = (
-            f'test -f /usr/local/share/ca-certificates/{cert_name}.crt'
-            f' || test -f /etc/pki/ca-trust/source/anchors/{cert_name}.pem'
-        )
         try:
-            result = self._run_nsenter(check_script)
-            if result is None:
-                return False
-            return result.returncode == 0
+            for cert_name, _ in self._all_container_certs():
+                check_script = (
+                    f'test -f /usr/local/share/ca-certificates/{cert_name}.crt'
+                    f' || test -f /etc/pki/ca-trust/source/anchors/{cert_name}.pem'
+                )
+                result = self._run_nsenter(check_script)
+                if result is None or result.returncode != 0:
+                    return False
+            return True
         except Exception:
             return False
 
@@ -4297,30 +4630,31 @@ class FumitmPython:
         Returns:
             tuple: (success: bool, message: str)
         """
-        cert_name = self.provider['container_cert_name']
-        # Debian/Alpine use .crt in /usr/local/share/ca-certificates/
-        # Fedora/RHEL use .pem in /etc/pki/ca-trust/source/anchors/
-        install_script = (
-            f'if [ -d /usr/local/share/ca-certificates ]; then'
-            f'  cat > /usr/local/share/ca-certificates/{cert_name}.crt'
-            f'  && update-ca-certificates 2>/dev/null;'
-            f' elif [ -d /etc/pki/ca-trust/source/anchors ]; then'
-            f'  cat > /etc/pki/ca-trust/source/anchors/{cert_name}.pem'
-            f'  && update-ca-trust 2>/dev/null;'
-            f' else exit 1; fi'
-        )
+        # Each root is written under its own filename so multiple roots
+        # (primary provider + supplemental, e.g. Aikido) all land in the VM.
+        # Debian/Alpine use .crt in /usr/local/share/ca-certificates/;
+        # Fedora/RHEL use .pem in /etc/pki/ca-trust/source/anchors/.
         try:
-            with open(self.cert_path, 'r') as f:
-                cert_content = f.read()
-
-            result = self._run_nsenter(install_script, stdin_data=cert_content,
-                                       timeout=60)
-            if result is None:
-                return False, 'No Docker image available for nsenter (try: docker pull alpine)'
-            if result.returncode == 0:
-                return True, 'Certificate installed in Docker VM'
-            self.print_debug(f"nsenter stderr: {result.stderr.strip()}")
-            return False, 'nsenter command failed'
+            for cert_name, cert_path in self._all_container_certs():
+                install_script = (
+                    f'if [ -d /usr/local/share/ca-certificates ]; then'
+                    f'  cat > /usr/local/share/ca-certificates/{cert_name}.crt'
+                    f'  && update-ca-certificates 2>/dev/null;'
+                    f' elif [ -d /etc/pki/ca-trust/source/anchors ]; then'
+                    f'  cat > /etc/pki/ca-trust/source/anchors/{cert_name}.pem'
+                    f'  && update-ca-trust 2>/dev/null;'
+                    f' else exit 1; fi'
+                )
+                with open(cert_path, 'r') as f:
+                    cert_content = f.read()
+                result = self._run_nsenter(install_script, stdin_data=cert_content,
+                                           timeout=60)
+                if result is None:
+                    return False, 'No Docker image available for nsenter (try: docker pull alpine)'
+                if result.returncode != 0:
+                    self.print_debug(f"nsenter stderr: {result.stderr.strip()}")
+                    return False, 'nsenter command failed'
+            return True, 'Certificate installed in Docker VM'
         except subprocess.TimeoutExpired:
             return False, 'nsenter timed out'
         except Exception as e:
@@ -4381,10 +4715,7 @@ class FumitmPython:
         cert_name = f"{self.provider['container_cert_name']}.crt"
         cert_dest = os.path.join(docker_certs_dir, cert_name)
 
-        persistent_installed = (
-            os.path.exists(cert_dest)
-            and self.certificate_likely_exists_in_file(self.cert_path, cert_dest)
-        )
+        persistent_installed = self._container_certs_present(docker_certs_dir)
 
         vm_is_running = self._docker_is_running()
         vm_needs_cert = False
@@ -4407,10 +4738,7 @@ class FumitmPython:
             vm_failed = False
 
             if not persistent_installed:
-                self._safe_makedirs(docker_certs_dir)
-                shutil.copy(self.cert_path, cert_dest)
-                self._fix_ownership(cert_dest)
-                self.print_info(f"Certificate installed to {cert_dest}")
+                self._install_container_certs(docker_certs_dir)
                 persistent_changed = True
 
             if vm_is_running and vm_needs_cert:
@@ -4760,7 +5088,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                 "(brew postinstall ca-certificates)"
             )
             has_issues = True
-        elif self.certificate_exists_in_file(temp_warp_cert, bundle_path):
+        elif self._status_roots_present(temp_warp_cert, bundle_path):
             self.print_info(
                 "  ✓ Homebrew CA bundle contains proxy certificate"
             )
@@ -4789,7 +5117,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     self.print_action("    Run with --fix to migrate to the current provider's bundle")
                     has_issues = True
                 elif os.path.exists(node_extra_ca_certs):
-                    if self.certificate_exists_in_file(temp_warp_cert, node_extra_ca_certs):
+                    if self._status_roots_present(temp_warp_cert, node_extra_ca_certs):
                         self.print_info("  ✓ NODE_EXTRA_CA_CERTS contains current certificate")
                         verify_result = self.verify_connection("node")
                         if verify_result == "WORKING":
@@ -4821,7 +5149,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                             self.print_action("    Run with --fix to migrate to the current provider's bundle")
                             has_issues = True
                         elif os.path.exists(npm_cafile):
-                            if self.certificate_exists_in_file(temp_warp_cert, npm_cafile):
+                            if self._status_roots_present(temp_warp_cert, npm_cafile):
                                 self.print_info("  ✓ npm cafile contains current certificate")
                                 suspicious, reason = self.is_suspicious_full_bundle(npm_cafile, None)
                                 if suspicious:
@@ -4862,7 +5190,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                         elif yarn_cafile == npm_bundle:
                             self.print_info(f"  ✓ yarn {config_key} points to managed npm bundle")
                         elif os.path.exists(yarn_cafile):
-                            if self.certificate_exists_in_file(temp_warp_cert, yarn_cafile):
+                            if self._status_roots_present(temp_warp_cert, yarn_cafile):
                                 self.print_info(f"  ✓ yarn {config_key} contains current certificate")
                             else:
                                 self.print_warn(f"  ⚠ yarn {config_key} doesn't contain proxy certificate: {yarn_cafile}")
@@ -4894,7 +5222,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                         elif pnpm_cafile == npm_bundle:
                             self.print_info("  ✓ pnpm cafile points to managed npm bundle")
                         elif os.path.exists(pnpm_cafile):
-                            if self.certificate_exists_in_file(temp_warp_cert, pnpm_cafile):
+                            if self._status_roots_present(temp_warp_cert, pnpm_cafile):
                                 self.print_info("  ✓ pnpm cafile contains current certificate")
                             else:
                                 self.print_warn(f"  ⚠ pnpm cafile doesn't contain proxy certificate: {pnpm_cafile}")
@@ -4922,6 +5250,21 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             if python_verify_result == "WORKING":
                 self.print_info("  ✓ Python trusts the system proxy certificate")
                 self.print_info("  ✓ Python can connect through proxy without additional configuration")
+                # verify_connection() exercises Python's default trust (which
+                # honors REQUESTS_CA_BUNDLE), but rustls clients such as uv read
+                # SSL_CERT_FILE instead. A managed SSL_CERT_FILE that is missing
+                # a required root (e.g. the Aikido supplemental root) leaves uv
+                # broken even though Python itself works, so flag it explicitly.
+                ssl_cert_file = os.environ.get('SSL_CERT_FILE', '')
+                if ssl_cert_file and os.path.exists(ssl_cert_file):
+                    if not self._status_roots_present(temp_warp_cert, ssl_cert_file):
+                        self.print_warn(
+                            f"  ✗ SSL_CERT_FILE ({ssl_cert_file}) is missing a required root"
+                        )
+                        self.print_action(
+                            "    Run with --fix to add all roots (needed by uv/rustls clients)"
+                        )
+                        has_issues = True
             else:
                 # Python doesn't trust system cert, check environment variables
                 python_configured = False
@@ -4930,7 +5273,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                 if requests_ca_bundle:
                     self.print_info(f"  REQUESTS_CA_BUNDLE is set to: {requests_ca_bundle}")
                     if os.path.exists(requests_ca_bundle):
-                        if self.certificate_exists_in_file(temp_warp_cert, requests_ca_bundle):
+                        if self._status_roots_present(temp_warp_cert, requests_ca_bundle):
                             self.print_info("  ✓ REQUESTS_CA_BUNDLE contains current certificate")
                             suspicious, reason = self.is_suspicious_full_bundle(requests_ca_bundle, None)
                             if suspicious:
@@ -4949,7 +5292,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                 if ssl_cert_file:
                     self.print_info(f"  SSL_CERT_FILE is set to: {ssl_cert_file}")
                     if os.path.exists(ssl_cert_file):
-                        if self.certificate_exists_in_file(temp_warp_cert, ssl_cert_file):
+                        if self._status_roots_present(temp_warp_cert, ssl_cert_file):
                             self.print_info("  ✓ SSL_CERT_FILE contains current certificate")
                             suspicious, reason = self.is_suspicious_full_bundle(ssl_cert_file, None)
                             if suspicious:
@@ -4992,7 +5335,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
 
                     if gcloud_ca and os.path.exists(gcloud_ca):
                         self.print_info(f"  - Custom CA configured at: {gcloud_ca}")
-                        if self.certificate_exists_in_file(temp_warp_cert, gcloud_ca):
+                        if self._status_roots_present(temp_warp_cert, gcloud_ca):
                             self.print_info("  ✓ Custom CA contains current certificate")
                         else:
                             self.print_warn("  ✗ gcloud CA file doesn't contain current certificate")
@@ -5015,7 +5358,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     gcloud_ca = result.stdout.strip() if result.returncode == 0 else ""
 
                     if gcloud_ca and os.path.exists(gcloud_ca):
-                        if self.certificate_exists_in_file(temp_warp_cert, gcloud_ca):
+                        if self._status_roots_present(temp_warp_cert, gcloud_ca):
                             self.print_info("  ✓ gcloud configured with current certificate")
                             suspicious, reason = self.is_suspicious_full_bundle(gcloud_ca, None)
                             if suspicious:
@@ -5041,7 +5384,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     gcloud_ca = result.stdout.strip() if result.returncode == 0 else ""
 
                     if gcloud_ca and os.path.exists(gcloud_ca):
-                        if self.certificate_exists_in_file(temp_warp_cert, gcloud_ca):
+                        if self._status_roots_present(temp_warp_cert, gcloud_ca):
                             self.print_warn("  - Custom CA is configured with WARP cert but connection still fails")
                             self.print_action("    Check gcloud and Python configuration")
                         else:
@@ -5254,7 +5597,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             cert_path = os.path.join(docker_certs_dir, f"{self.provider['container_cert_name']}.crt")
 
             if os.path.exists(cert_path):
-                if self.certificate_likely_exists_in_file(temp_warp_cert, cert_path):
+                if self._status_roots_present(temp_warp_cert, cert_path, likely=True):
                     self.print_info("  ✓ Certificate installed in ~/.docker/certs.d/ (persistent)")
                 else:
                     self.print_warn("  ✗ Certificate in ~/.docker/certs.d/ is outdated")
@@ -5296,7 +5639,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             cert_path = os.path.join(docker_certs_dir, f"{self.provider['container_cert_name']}.crt")
 
             if os.path.exists(cert_path):
-                if self.certificate_likely_exists_in_file(temp_warp_cert, cert_path):
+                if self._status_roots_present(temp_warp_cert, cert_path, likely=True):
                     self.print_info("  ✓ Certificate installed in ~/.docker/certs.d/ (persistent)")
                 else:
                     self.print_warn("  ✗ Certificate in ~/.docker/certs.d/ is outdated")
@@ -5336,7 +5679,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             )
 
             if os.path.exists(cert_path):
-                if self.certificate_likely_exists_in_file(temp_warp_cert, cert_path):
+                if self._status_roots_present(temp_warp_cert, cert_path, likely=True):
                     self.print_info("  ✓ Certificate installed in ~/.docker/certs.d/ (persistent)")
                 else:
                     self.print_warn("  ✗ Certificate in ~/.docker/certs.d/ is outdated")
@@ -5386,7 +5729,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             cert_path = os.path.join(docker_certs_dir, f"{self.provider['container_cert_name']}.crt")
 
             if os.path.exists(cert_path):
-                if self.certificate_likely_exists_in_file(temp_warp_cert, cert_path):
+                if self._status_roots_present(temp_warp_cert, cert_path, likely=True):
                     self.print_info("  ✓ Certificate installed in ~/.docker/certs.d/ (persistent)")
                 else:
                     self.print_warn("  ✗ Certificate in ~/.docker/certs.d/ is outdated")
@@ -5534,6 +5877,11 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
         self.cert_fingerprint = self.get_cert_fingerprint(temp_warp_cert)
         self.print_debug(f"{short} certificate fingerprint: {self.cert_fingerprint}")
 
+        # Materialize supplemental roots so per-tool status checks can verify
+        # each managed bundle contains them alongside the primary cert.
+        self._prepare_extra_roots()
+        self._announce_extra_roots()
+
         # Check provider connection
         if self._check_provider_connection():
             has_issues = True
@@ -5625,7 +5973,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             docker_certs_dir = os.path.expanduser("~/.docker/certs.d")
             cert_path = os.path.join(docker_certs_dir, f"{self.provider['container_cert_name']}.crt")
             if os.path.exists(cert_path):
-                if self.certificate_likely_exists_in_file(temp_warp_cert, cert_path):
+                if self._container_certs_present(docker_certs_dir):
                     self.print_info(f"  ✓ Certificate installed in {docker_certs_dir}")
                     self.print_info("    (Used by: Docker, OrbStack, Colima, Podman, Rancher Desktop, Lima)")
                     self._print_docker_build_hint()
@@ -5803,6 +6151,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
         try:
             return self._main_inner()
         finally:
+            self._cleanup_extra_root_temp_files()
             self._close_log_files()
 
     def _main_inner(self):
@@ -5880,6 +6229,11 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                 if not self.download_certificate():
                     self.print_error("Failed to download certificate. Exiting.")
                     return 1
+
+                # Materialize any supplemental roots (e.g. Aikido) so every tool
+                # fixer can append them alongside the primary provider cert.
+                self._prepare_extra_roots()
+                self._announce_extra_roots()
 
                 if self.selected_tools:
                     self.print_info(f"Processing selected tools: {', '.join(self.get_selected_tools_info())}")
@@ -5972,6 +6326,11 @@ def main():
                         help='Skip network verification tests (useful in devcontainers)')
     parser.add_argument('--provider', choices=list(PROVIDERS.keys()),
                         help='MITM proxy provider (default: auto-detect)')
+    parser.add_argument('--with-aikido', action='store_true',
+                        help='Force-add the Aikido Endpoint Protection root CA to all '
+                             'bundles even if it is not auto-detected')
+    parser.add_argument('--no-aikido', action='store_true',
+                        help='Do not add the Aikido root CA even if Aikido is detected')
     parser.add_argument('--yes', '-y', action='store_true',
                         help='Answer yes to all prompts (for non-interactive use)')
     parser.add_argument('--debug', '--verbose', action='store_true',
@@ -6046,6 +6405,9 @@ def main():
                 [t.strip() for t in tool_arg.split(',') if t.strip()]
             )
 
+    if args.with_aikido and args.no_aikido:
+        parser.error('--with-aikido and --no-aikido are mutually exclusive')
+
     mode = 'install' if args.fix else 'status'
 
     fumitm_instance = FumitmPython(
@@ -6065,6 +6427,8 @@ def main():
         json_log_file=args.json_log_file,
         json_log_dir=args.json_log_dir,
         run_as_user=args.run_as_user,
+        with_aikido=args.with_aikido,
+        no_aikido=args.no_aikido,
     )
     exit_code = fumitm_instance.main()
     sys.exit(exit_code)

--- a/fumitm.py
+++ b/fumitm.py
@@ -221,19 +221,34 @@ ToolResult = namedtuple(
 
 
 class FumitmPython:
+    # Markers delimiting fumitm's managed export block in the shell config. The
+    # block is always re-emitted at the end of the file so its TLS-trust settings
+    # win over any earlier vendor block (e.g. Aikido) via last-export-wins.
+    _FUMITM_BLOCK_BEGIN = "# >>> fumitm managed (keep last) >>>"
+    _FUMITM_BLOCK_END = "# <<< fumitm managed <<<"
+
     def __init__(self, mode='status', debug=False, selected_tools=None,
                  cert_file=None, manual_cert=False, skip_verify=False,
                  provider=None, auto_yes=False, no_color=False,
                  headless=False, skip_update_check=False,
                  log_file=None, log_dir=None,
                  json_log_file=None, json_log_dir=None,
-                 run_as_user=None, with_aikido=False, no_aikido=False):
+                 run_as_user=None, with_aikido=False, no_aikido=False,
+                 aikido_cert_file=None):
         self.mode = mode
         self.debug = debug
         self.shell_modified = False
+        # Shell config paths whose pre-run original has already been backed up
+        # this run, so repeated writes in one run never overwrite the .bak with an
+        # intermediate generated file.
+        self._backed_up_shell_configs = set()
         self.cert_fingerprint = ""
         self.selected_tools = selected_tools or []
         self.cert_file = cert_file
+        # Stored raw and expanded at read time: --run-as-user/sudo targeting
+        # rewrites HOME later in __init__, so a tilde path must not be expanded
+        # against root's home here.
+        self.aikido_cert_file = aikido_cert_file
         self.manual_cert = manual_cert
         self.skip_verify = skip_verify
         self.auto_yes = auto_yes
@@ -546,9 +561,11 @@ class FumitmPython:
         """
         active = []
         # Aikido is the only supplemental root today; the structure generalizes
-        # so future vendors slot in the same way.
+        # so future vendors slot in the same way. Supplying an explicit cert file
+        # implies the operator wants Aikido active, mirroring --with-aikido.
         aikido_forced_off = no_aikido
-        aikido_active = with_aikido or (not aikido_forced_off and self._detect_aikido())
+        aikido_forced_on = with_aikido or bool(self.aikido_cert_file)
+        aikido_active = aikido_forced_on or (not aikido_forced_off and self._detect_aikido())
         if aikido_active:
             entry = dict(SUPPLEMENTAL_ROOTS['aikido'])
             entry['key'] = 'aikido'
@@ -587,10 +604,13 @@ class FumitmPython:
     def _get_aikido_root_cert(self):
         """Retrieve the Aikido root CA certificate(s) as PEM text.
 
-        Tries the macOS System Keychain first (by label prefix), then falls back
-        to parsing the maintained combined PEM. Only certificates whose subject
-        CN starts with the Aikido root prefix are kept; the ephemeral hex-CN
-        interception intermediate is deliberately excluded.
+        Sources are tried in order: an operator-supplied file (``--aikido-cert``),
+        the macOS System Keychain (by label prefix), the maintained combined PEM,
+        and finally a root persisted by an earlier run. The explicit and persisted
+        sources are what let ``--with-aikido`` succeed on hosts where the live
+        Aikido agent is absent, such as CI or no-agent images. Only certificates
+        whose subject CN starts with the Aikido root prefix are kept; the ephemeral
+        hex-CN interception intermediate is deliberately excluded.
 
         Returns:
             str or None: PEM text containing the Aikido root(s), or None.
@@ -598,7 +618,18 @@ class FumitmPython:
         descriptor = SUPPLEMENTAL_ROOTS['aikido']
         prefix = descriptor['keychain_label_prefix']
 
-        # Source 1: macOS System Keychain, all matching certs by label prefix.
+        # Source 1: explicit operator-supplied file. This is the supported path
+        # for forcing Aikido on hosts where no live agent or keychain entry
+        # exists; failure here is surfaced rather than silently falling through.
+        if self.aikido_cert_file:
+            cert_path = os.path.expanduser(self.aikido_cert_file)
+            pem = self._read_aikido_root_from_file(cert_path, prefix)
+            if pem:
+                self.print_info(f"Using Aikido root CA from {cert_path}")
+                return pem
+            self.print_warn(f"No Aikido root CA found in {cert_path}")
+
+        # Source 2: macOS System Keychain, all matching certs by label prefix.
         if platform.system() == 'Darwin':
             try:
                 result = subprocess.run(
@@ -614,19 +645,40 @@ class FumitmPython:
             except Exception as e:
                 self.print_debug(f"Aikido keychain extraction failed: {e}")
 
-        # Source 2: maintained combined PEM on disk.
-        combined = descriptor['combined_pem']
-        if os.path.exists(combined):
-            try:
-                with open(combined, 'r') as f:
-                    roots = self._filter_certs_by_cn_prefix(f.read(), prefix)
-                if roots:
-                    self.print_info(f"Using Aikido root CA from {combined}")
-                    return '\n'.join(roots)
-            except Exception as e:
-                self.print_debug(f"Could not parse Aikido combined PEM: {e}")
+        # Source 3: maintained combined PEM written by the live Aikido agent.
+        pem = self._read_aikido_root_from_file(descriptor['combined_pem'], prefix)
+        if pem:
+            self.print_info(f"Using Aikido root CA from {descriptor['combined_pem']}")
+            return pem
+
+        # Source 4: a root persisted by an earlier fumitm run. This keeps
+        # --with-aikido working after the live agent is removed or unavailable.
+        persisted = os.path.expanduser(descriptor['cert_path'])
+        pem = self._read_aikido_root_from_file(persisted, prefix)
+        if pem:
+            self.print_info(f"Using previously saved Aikido root CA from {persisted}")
+            return pem
 
         self.print_warn("Could not extract Aikido root CA; skipping supplemental trust")
+        return None
+
+    def _read_aikido_root_from_file(self, path, cn_prefix):
+        """Return CN-prefix-filtered Aikido root PEM text from a file, or None.
+
+        Reads the file at ``path`` (if it exists), keeps only the certificate
+        blocks whose subject CN starts with ``cn_prefix``, and returns them
+        joined as PEM text. Returns None when the file is absent, unreadable, or
+        contains no matching root.
+        """
+        if not path or not os.path.exists(path):
+            return None
+        try:
+            with open(path, 'r') as f:
+                roots = self._filter_certs_by_cn_prefix(f.read(), cn_prefix)
+            if roots:
+                return '\n'.join(roots)
+        except Exception as e:
+            self.print_debug(f"Could not parse Aikido root from {path}: {e}")
         return None
 
     def _filter_certs_by_cn_prefix(self, pem_text, cn_prefix):
@@ -1693,54 +1745,90 @@ class FumitmPython:
     def certificate_likely_exists_in_file(self, cert_file, target_file):
         """Fast certificate check using pure Python string matching.
 
-        This function uses no subprocess calls for performance. It extracts
-        the first 100 characters of base64 content from the certificate and
-        searches for that unique portion in the target file.
+        Verifies that *every* certificate in cert_file is present in
+        target_file, identifying each by the first 100 characters of its base64
+        body. This matters when cert_file holds more than one certificate — for
+        example several Aikido roots returned during a root rotation — since a
+        bundle missing a later root must not be reported as complete. Uses no
+        subprocess calls for performance.
 
         Args:
-            cert_file: Path to the certificate to search for
+            cert_file: Path to the certificate(s) to search for
             target_file: Path to the bundle file to search in
 
         Returns:
-            bool: True if certificate likely exists in target file
+            bool: True if every certificate in cert_file exists in target_file
         """
         if not os.path.exists(target_file) or not os.path.exists(cert_file):
             return False
 
         try:
-            # Extract base64 content from cert file (skip BEGIN/END markers)
-            with open(cert_file, 'r') as f:
-                cert_lines = []
-                in_cert = False
-                for line in f:
-                    if '-----BEGIN CERTIFICATE-----' in line:
-                        in_cert = True
-                    elif '-----END CERTIFICATE-----' in line:
-                        in_cert = False
-                    elif in_cert:
-                        cert_lines.append(line.strip())
+            unique_portions = self._cert_unique_portions(cert_file)
+            if not unique_portions:
+                return False
 
-                if not cert_lines:
-                    return False
-
-                # Get first 100 chars of base64 content - enough to be unique
-                cert_unique_portion = ''.join(cert_lines)[:100]
-
-            # Search for this unique portion in target file
+            # Normalize whitespace and require every certificate to be present.
             with open(target_file, 'r') as tf:
-                target_content = tf.read()
-                # Normalize whitespace for comparison
-                target_normalized = ''.join(target_content.split())
+                target_normalized = ''.join(tf.read().split())
 
-                if cert_unique_portion in target_normalized:
-                    self.print_debug(f"Certificate likely exists in {target_file} (found matching content)")
-                    return True
+            for unique_portion in unique_portions:
+                if unique_portion not in target_normalized:
+                    return False
+            self.print_debug(f"All certificates found in {target_file}")
+            return True
 
         except Exception as e:
             self.print_debug(f"Error checking certificate content: {e}")
 
         return False
-    
+
+    def _cert_unique_portions(self, cert_file):
+        """Return a unique base64 fingerprint per certificate in cert_file.
+
+        Each certificate is identified by the first 100 characters of its base64
+        body — enough to be unique while needing no subprocess calls. The list
+        preserves file order and is empty when the file holds no certificate.
+        """
+        unique_portions = []
+        current = []
+        in_cert = False
+        with open(cert_file, 'r') as f:
+            for line in f:
+                if '-----BEGIN CERTIFICATE-----' in line:
+                    in_cert = True
+                    current = []
+                elif '-----END CERTIFICATE-----' in line:
+                    in_cert = False
+                    body = ''.join(current)
+                    if body:
+                        unique_portions.append(body[:100])
+                elif in_cert:
+                    current.append(line.strip())
+        return unique_portions
+
+    def _any_cert_present_in_file(self, cert_file, target_file):
+        """Return True if at least one certificate from cert_file is in target_file.
+
+        This is the permissive counterpart to certificate_likely_exists_in_file.
+        It tells whether brew sourced any part of a multi-certificate provider
+        bundle (e.g. Netskope's combined root plus intermediate) from the
+        keychain: a bundle holding the root but not the intermediate still counts
+        as sourced, so the intermediate can be topped up by direct append rather
+        than reported as a keychain failure.
+        """
+        if not os.path.exists(target_file) or not os.path.exists(cert_file):
+            return False
+        try:
+            unique_portions = self._cert_unique_portions(cert_file)
+            if not unique_portions:
+                return False
+            with open(target_file, 'r') as tf:
+                target_normalized = ''.join(tf.read().split())
+            return any(portion in target_normalized for portion in unique_portions)
+        except Exception as e:
+            self.print_debug(f"Error checking certificate content: {e}")
+            return False
+
     def certificate_exists_in_file(self, cert_file, target_file):
         """Check if a certificate already exists in a file.
 
@@ -1913,81 +2001,116 @@ class FumitmPython:
             self.print_error(f"Failed to append certificate to {target_file}: {e}")
             return False
 
+    def _parse_fumitm_block(self, content):
+        """Split shell-config content into foreign lines and the managed block.
+
+        Returns a tuple of (other_lines, managed) where other_lines preserves
+        every line outside fumitm's managed block verbatim (user lines and any
+        vendor block such as Aikido's), and managed is an insertion-ordered dict
+        of the var->value pairs parsed from inside the block.
+
+        The last begin marker is paired with the first end marker that follows
+        it, so a stale unmatched begin marker left earlier in the file is treated
+        as foreign content rather than being closed by a fresh block's end marker.
+        A begin marker with no following end is malformed: all content is kept
+        verbatim and the block is reported empty so a fresh one is appended.
+        """
+        lines = content.splitlines()
+        begin_idx = None
+        for i, line in enumerate(lines):
+            if line.strip() == self._FUMITM_BLOCK_BEGIN:
+                begin_idx = i
+        if begin_idx is None:
+            return lines, {}
+
+        end_idx = None
+        for i in range(begin_idx + 1, len(lines)):
+            if lines[i].strip() == self._FUMITM_BLOCK_END:
+                end_idx = i
+                break
+        if end_idx is None:
+            self.print_warn(
+                "Found an unterminated fumitm block marker in the shell config; "
+                "leaving existing content untouched and appending a fresh block"
+            )
+            return lines, {}
+
+        managed = {}
+        for line in lines[begin_idx + 1:end_idx]:
+            stripped = line.strip()
+            if not stripped.startswith('export '):
+                continue
+            try:
+                name, rhs = stripped[len('export '):].split('=', 1)
+            except ValueError:
+                continue
+            rhs = rhs.strip()
+            if (rhs.startswith('"') and rhs.endswith('"')) or \
+                    (rhs.startswith("'") and rhs.endswith("'")):
+                rhs = rhs[1:-1]
+            managed[name.strip()] = rhs
+
+        other_lines = lines[:begin_idx] + lines[end_idx + 1:]
+        return other_lines, managed
+
+    def _render_fumitm_block(self, managed):
+        """Render the managed export block as text (double-quoted values)."""
+        body = [self._FUMITM_BLOCK_BEGIN]
+        body.extend(f'export {name}="{value}"' for name, value in managed.items())
+        body.append(self._FUMITM_BLOCK_END)
+        return '\n'.join(body)
+
     def add_to_shell_config(self, var_name, var_value, shell_config):
-        """Add export to shell config."""
-        # Check if the export already exists
+        """Upsert an export into fumitm's managed, always-last shell-config block.
+
+        fumitm keeps its TLS-trust exports in a single marker-delimited block that
+        is re-emitted at the end of the file on every write. This guarantees the
+        exports sit after any earlier vendor block (e.g. Aikido) so they win by
+        last-export-wins, without ever editing the vendor's block. A user's own
+        earlier export of the same variable is preserved but overridden.
+
+        Returns:
+            bool: True when the file changed (or would change in dry-run mode),
+            False on a no-op. The gcloud setup uses this to report pre-bootstrap.
+        """
+        original = None
         if os.path.exists(shell_config):
             with open(shell_config, 'r') as f:
-                content = f.read()
+                original = f.read()
 
-            # Find the first active (non-commented) export of this variable
-            # and compare its value to what we would write. If they already
-            # match, this is a no-op and we should not warn or prompt.
-            active_line = None
-            for line in content.splitlines():
-                stripped = line.strip()
-                if stripped.startswith('#'):
-                    continue
-                if stripped.startswith(f"export {var_name}="):
-                    active_line = stripped
-                    break
+        other_lines, managed = self._parse_fumitm_block(original or "")
+        managed[var_name] = var_value
 
-            if active_line is not None:
-                rhs = active_line.split('=', 1)[1].strip()
-                if (rhs.startswith('"') and rhs.endswith('"')) or \
-                        (rhs.startswith("'") and rhs.endswith("'")):
-                    rhs = rhs[1:-1]
-                if rhs == var_value:
-                    # Already set to the desired value — quietly do nothing
-                    # so repeated runs are idempotent and we don't claim a
-                    # change in the summary or trigger a stale "reload your
-                    # shell" hint.
-                    return
+        while other_lines and other_lines[-1].strip() == '':
+            other_lines.pop()
+        prefix = ('\n'.join(other_lines) + '\n\n') if other_lines else ''
+        new = prefix + self._render_fumitm_block(managed) + '\n'
 
-                self.print_warn(f"{var_name} already exists in {shell_config}")
-                self.print_info(f"Current value: {active_line}")
+        changed = original is None or new != original
 
-                if not self.is_install_mode():
-                    self.print_action(f"Would ask to update {var_name} in {shell_config}")
-                    self.print_action(f"Would set: export {var_name}=\"{var_value}\"")
-                else:
-                    response = self._prompt("Do you want to update it? (y/N) ")
-                    if response.lower() == 'y':
-                        # Comment out old entries
-                        lines = content.splitlines()
-                        new_lines = []
-                        for line in lines:
-                            if line.strip().startswith(f"export {var_name}="):
-                                new_lines.append(f"#{line}")
-                            else:
-                                new_lines.append(line)
-                        
-                        # Add new entry
-                        new_lines.append(f'export {var_name}="{var_value}"')
-                        
-                        # Write back
-                        with open(shell_config + '.bak', 'w') as f:
-                            f.write(content)
-                        self._fix_ownership(shell_config + '.bak')
-                        with open(shell_config, 'w') as f:
-                            f.write('\n'.join(new_lines) + '\n')
-                        self._fix_ownership(shell_config)
-
-                        self.shell_modified = True
-                        self.print_info(f"Updated {var_name} in {shell_config}")
-                return
-
-        # Variable doesn't exist, add it
         if not self.is_install_mode():
-            self.print_action(f"Would add to {shell_config}:")
-            self.print_action(f'export {var_name}="{var_value}"')
-        else:
-            with open(shell_config, 'a') as f:
-                f.write(f'\nexport {var_name}="{var_value}"\n')
-            self._fix_ownership(shell_config)
-            self.shell_modified = True
-            self.print_info(f"Added {var_name} to {shell_config}")
-    
+            if changed:
+                self.print_action(f"Would add to {shell_config}:")
+                self.print_action(f'export {var_name}="{var_value}"')
+            return changed
+
+        if not changed:
+            return False
+
+        if shell_config not in self._backed_up_shell_configs:
+            if original is not None:
+                with open(shell_config + '.bak', 'w') as f:
+                    f.write(original)
+                self._fix_ownership(shell_config + '.bak')
+            self._backed_up_shell_configs.add(shell_config)
+
+        with open(shell_config, 'w') as f:
+            f.write(new)
+        self._fix_ownership(shell_config)
+        self.shell_modified = True
+        self.print_info(f"Set {var_name} in {shell_config}")
+        return True
+
     def is_devcontainer(self):
         """Check if running inside a VS Code devcontainer."""
         # Check for devcontainer environment variables
@@ -2587,6 +2710,31 @@ class FumitmPython:
                 return False
         return True
 
+    def _status_container_certs_present(self, primary_cert_path, docker_certs_dir):
+        """Status-mode check that every proxy root is present in its own file.
+
+        Install writes the primary provider root and each supplemental root to
+        separate {container_cert_name}.crt files, so each must be checked in its
+        own file rather than expecting the primary file to contain them all. The
+        primary is compared against the supplied temp cert because status mode may
+        not have written cert_path. With no supplemental roots active this reduces
+        to the single primary-file check, preserving behavior.
+        """
+        primary_dest = os.path.join(
+            docker_certs_dir, f"{self.provider['container_cert_name']}.crt"
+        )
+        if not (os.path.exists(primary_dest)
+                and self.certificate_likely_exists_in_file(primary_cert_path, primary_dest)):
+            return False
+        for entry in self.extra_roots:
+            if not entry.get('path'):
+                continue
+            dest = os.path.join(docker_certs_dir, f"{entry['container_cert_name']}.crt")
+            if not (os.path.exists(dest)
+                    and self.certificate_likely_exists_in_file(entry['path'], dest)):
+                return False
+        return True
+
     def _install_container_certs(self, docker_certs_dir):
         """Copy every proxy root into ~/.docker/certs.d as {name}.crt."""
         self._safe_makedirs(docker_certs_dir)
@@ -2658,44 +2806,13 @@ class FumitmPython:
 
         if not os.path.exists(bundle_path):
             self.print_debug(f"Homebrew CA bundle not found at {bundle_path}")
+            self.print_info("Configuring Homebrew CA certificates...")
             if not self.is_install_mode():
-                self.print_info("Configuring Homebrew CA certificates...")
                 self.print_action(
                     "Would run: brew postinstall ca-certificates"
                 )
-            else:
-                self.print_info("Configuring Homebrew CA certificates...")
-                result = subprocess.run(
-                    ['brew', 'postinstall', 'ca-certificates'],
-                    capture_output=True, text=True
-                )
-                if result.returncode == 0:
-                    if self.certificate_exists_in_file(
-                        self.cert_path, bundle_path
-                    ):
-                        self.print_info(
-                            "Homebrew CA bundle now includes "
-                            "proxy certificate"
-                        )
-                        return ToolResult('brew-cacerts', 'configured', 'Bundle regenerated with proxy certificate')
-                    else:
-                        self.print_warn(
-                            "brew postinstall succeeded but proxy "
-                            "certificate not found in bundle"
-                        )
-                        self.print_warn(
-                            "The proxy CA may not be in the "
-                            "macOS system keychain"
-                        )
-                        return ToolResult('brew-cacerts', 'failed', 'Proxy certificate not found in bundle after postinstall')
-                else:
-                    self.print_error(
-                        "brew postinstall ca-certificates failed"
-                    )
-                    if result.stderr:
-                        self.print_debug(result.stderr.strip())
-                    return ToolResult('brew-cacerts', 'failed', 'brew postinstall ca-certificates failed')
-            return ToolResult('brew-cacerts', 'skipped', 'Dry run')
+                return ToolResult('brew-cacerts', 'skipped', 'Dry run')
+            return self._run_brew_postinstall(bundle_path)
 
         if self._all_roots_present_in_file(bundle_path):
             self.print_debug(
@@ -2708,38 +2825,59 @@ class FumitmPython:
             self.print_action(
                 "Would run: brew postinstall ca-certificates"
             )
-        else:
-            self.print_info(
-                "Regenerating Homebrew CA bundle to include proxy certificate..."
+            return ToolResult('brew-cacerts', 'skipped', 'Dry run')
+        self.print_info(
+            "Regenerating Homebrew CA bundle to include proxy certificate..."
+        )
+        return self._run_brew_postinstall(bundle_path)
+
+    def _run_brew_postinstall(self, bundle_path):
+        """Regenerate the Homebrew CA bundle and verify every proxy root landed.
+
+        brew rebuilds the bundle from the macOS system keychain. Certificates
+        that live only in the maintained combined PEM are therefore dropped: a
+        provider intermediate the keychain lacks (e.g. Netskope ships root plus
+        intermediate but the keychain holds only the root) and every supplemental
+        root (e.g. Aikido). Whatever is missing is appended to the regenerated
+        bundle directly. Failure is reported only when brew sourced no part of
+        the primary proxy CA, which signals the keychain is missing it entirely;
+        appending the primary there would be wiped on the next ca-certificates
+        upgrade, so the keychain problem is surfaced instead.
+        """
+        result = subprocess.run(
+            ['brew', 'postinstall', 'ca-certificates'],
+            capture_output=True, text=True
+        )
+        if result.returncode != 0:
+            self.print_error("brew postinstall ca-certificates failed")
+            if result.stderr:
+                self.print_debug(result.stderr.strip())
+            return ToolResult('brew-cacerts', 'failed', 'brew postinstall ca-certificates failed')
+
+        if not self._any_cert_present_in_file(self.cert_path, bundle_path):
+            self.print_warn(
+                "brew postinstall succeeded but proxy certificate "
+                "not found in bundle"
             )
-            result = subprocess.run(
-                ['brew', 'postinstall', 'ca-certificates'],
-                capture_output=True, text=True
+            self.print_warn(
+                "The proxy CA may not be in the macOS system keychain"
             )
-            if result.returncode == 0:
-                if self.certificate_exists_in_file(
-                    self.cert_path, bundle_path
-                ):
-                    self.print_info(
-                        "Homebrew CA bundle now includes proxy certificate"
-                    )
-                    return ToolResult('brew-cacerts', 'configured', 'Bundle regenerated with proxy certificate')
-                else:
-                    self.print_warn(
-                        "brew postinstall succeeded but proxy certificate "
-                        "not found in bundle"
-                    )
-                    self.print_warn(
-                        "The proxy CA may not be in the macOS system keychain"
-                    )
-                    return ToolResult('brew-cacerts', 'failed', 'Proxy certificate not found in bundle after postinstall')
-            else:
-                self.print_error(
-                    "brew postinstall ca-certificates failed"
+            return ToolResult('brew-cacerts', 'failed', 'Proxy certificate not found in bundle after postinstall')
+
+        if not self._all_roots_present_in_file(bundle_path):
+            # brew sourced the primary root from the keychain but dropped certs
+            # that live only in the combined PEM (provider intermediate and any
+            # supplemental root); append the missing ones directly.
+            self._append_all_proxy_roots(bundle_path)
+            if not self._all_roots_present_in_file(bundle_path):
+                self.print_warn(
+                    "Proxy certificate could not be added to the "
+                    "Homebrew CA bundle"
                 )
-                if result.stderr:
-                    self.print_debug(result.stderr.strip())
-                return ToolResult('brew-cacerts', 'failed', 'brew postinstall ca-certificates failed')
+                return ToolResult('brew-cacerts', 'failed', 'Proxy certificate not found in bundle after postinstall')
+
+        self.print_info("Homebrew CA bundle now includes proxy certificate")
+        return ToolResult('brew-cacerts', 'configured', 'Bundle regenerated with proxy certificate')
 
     def setup_node_cert(self):
         """Setup Node.js certificate."""
@@ -3092,6 +3230,24 @@ class FumitmPython:
         except Exception as e:
             self.print_debug(f"Error checking pnpm cafile: {e}")
 
+    def _export_python_trust_vars(self, bundle, shell_config):
+        """Point every Python-ecosystem TLS-trust var at the both-roots bundle.
+
+        Includes the vars a supplemental-root vendor (e.g. Aikido) exports at its
+        own single-root bundle — PIP_CERT, POETRY_CERTIFICATES_PYPI_CERT, and
+        BUNDLE_SSL_CA_CERT — so pip/poetry/bundler trust both proxies, not just
+        the vendor's. Returns True if any export changed the shell config.
+        """
+        trust_vars = (
+            'SSL_CERT_FILE', 'REQUESTS_CA_BUNDLE', 'CURL_CA_BUNDLE',
+            'PIP_CERT', 'POETRY_CERTIFICATES_PYPI_CERT', 'BUNDLE_SSL_CA_CERT',
+        )
+        changed = False
+        for var in trust_vars:
+            if self.add_to_shell_config(var, bundle, shell_config):
+                changed = True
+        return changed
+
     def setup_python_cert(self):
         """Setup Python certificate."""
         if not self.command_exists('python3') and not self.command_exists('python'):
@@ -3168,13 +3324,16 @@ class FumitmPython:
                     # Check if the existing bundle looks suspicious (likely just WARP CA)
                     suspicious, reason = self.is_suspicious_full_bundle(requests_ca_bundle, self.cert_path)
                     if suspicious:
+                        # Repoint at fumitm's managed bundle, then fall through to
+                        # the trust-var post-pass below rather than returning here:
+                        # an early return would leave the vendor vars
+                        # (PIP_CERT/Poetry/Bundler) pointing at the old bundle.
                         needs_setup = True
                         self.print_info("Configuring Python certificate...")
                         self.print_warn(f"REQUESTS_CA_BUNDLE looks suspiciously small ({reason})")
                         if not self.is_install_mode():
                             self.print_action(f"Would create full CA bundle at {python_bundle}")
                             self.print_action(f"Would repoint REQUESTS_CA_BUNDLE to {python_bundle}")
-                            return ToolResult('python', 'skipped', 'Dry run')
                         else:
                             self.create_bundle_with_system_certs(python_bundle)
                             self._append_all_proxy_roots(python_bundle)
@@ -3182,10 +3341,11 @@ class FumitmPython:
                             self.add_to_shell_config("SSL_CERT_FILE", python_bundle, shell_config)
                             self.add_to_shell_config("CURL_CA_BUNDLE", python_bundle, shell_config)
                             self.print_info(f"Repointed REQUESTS_CA_BUNDLE to managed bundle: {python_bundle}")
-                            return ToolResult('python', 'configured', 'Repointed suspicious REQUESTS_CA_BUNDLE')
 
-                    # Check if the file contains our certificate using normalized comparison
-                    if not self._all_roots_present_in_file(requests_ca_bundle):
+                    # Check if the file contains our certificate using normalized
+                    # comparison. Only when the bundle was not suspicious — the
+                    # suspicious branch has already abandoned it for python_bundle.
+                    elif not self._all_roots_present_in_file(requests_ca_bundle):
                         needs_setup = True
                         self.print_info("Configuring Python certificate...")
                         self.print_info(f"REQUESTS_CA_BUNDLE is already set to: {requests_ca_bundle}")
@@ -3273,6 +3433,34 @@ class FumitmPython:
                     self.add_to_shell_config("SSL_CERT_FILE", python_bundle, shell_config)
                     self.print_info(f"Repointed SSL_CERT_FILE to managed bundle: {python_bundle}")
 
+        # Reclaim the Python-ecosystem trust vars a supplemental-root vendor
+        # (e.g. Aikido) may have exported at its own single-root bundle. Earlier
+        # branches above can exit while PIP_CERT/POETRY/BUNDLE_SSL_CA_CERT still
+        # point at an Aikido-only bundle, so assert all of them at the both-roots
+        # Python bundle whenever Aikido is active or any vendor var is present.
+        vendor_trust_vars = (
+            'PIP_CERT', 'POETRY_CERTIFICATES_PYPI_CERT', 'BUNDLE_SSL_CA_CERT'
+        )
+        aikido_active = any(e['key'] == 'aikido' for e in self.extra_roots)
+        if aikido_active or any(os.environ.get(v) for v in vendor_trust_vars):
+            bundle_repaired = False
+            if self.is_install_mode():
+                # A bundle built before Aikido was active is stale and would still
+                # be missing the Aikido root, so repair it before pointing vars at it.
+                if not os.path.exists(python_bundle):
+                    self.create_bundle_with_system_certs(python_bundle)
+                    self._append_all_proxy_roots(python_bundle)
+                    bundle_repaired = True
+                elif not self._all_roots_present_in_file(python_bundle):
+                    self._append_all_proxy_roots(python_bundle)
+                    bundle_repaired = True
+            else:
+                bundle_repaired = (not os.path.exists(python_bundle)) or \
+                    (not self._all_roots_present_in_file(python_bundle))
+            exported = self._export_python_trust_vars(python_bundle, shell_config)
+            if bundle_repaired or exported:
+                needs_setup = True
+
         if not needs_setup:
             return ToolResult('python', 'already_ok', 'Python certificate already configured')
         if self.is_install_mode():
@@ -3355,6 +3543,38 @@ class FumitmPython:
                 self.print_info(f"Created {properties_file} with custom_ca_certs_file")
         return True
 
+    def _ensure_gcloud_reauth_trust(self, complete_bundle, shell_config):
+        """Make gcloud's reauth handshake trust the full proxy bundle.
+
+        The IAP tunnel and ordinary API calls read core/custom_ca_certs_file, but
+        the reauth flow — the reauth.googleapis.com session handshake gcloud runs
+        when credentials need refreshing — goes through gcloud's bundled requests
+        library, which ignores that property and trusts REQUESTS_CA_BUNDLE, then
+        CURL_CA_BUNDLE, instead. A supplemental-root vendor such as Aikido exports
+        both at its own combined bundle, which carries the public roots and the
+        vendor root but not the primary proxy root (e.g. Netskope) that actually
+        intercepts Google traffic. The reauth handshake then fails with
+        "self-signed certificate in certificate chain" even though the property is
+        correct and ``gcloud projects list`` otherwise works.
+
+        Re-assert both variables at the complete fumitm bundle (public roots plus
+        every proxy root). The always-last managed block wins over the vendor's
+        earlier export by last-export-wins. This only acts when a supplemental
+        root is active, leaving the environment of plain single-provider hosts
+        untouched.
+
+        Returns:
+            bool: True when a shell-config export changed (or would change in
+            dry-run mode), False otherwise.
+        """
+        if not self.extra_roots:
+            return False
+        changed = False
+        for var in ("REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"):
+            if self.add_to_shell_config(var, complete_bundle, shell_config):
+                changed = True
+        return changed
+
     def setup_gcloud_cert(self):
         """Setup gcloud certificate."""
         # Pre-create the gcloud properties file so that future gcloud installs
@@ -3366,20 +3586,15 @@ class FumitmPython:
             props_changed = self._ensure_gcloud_properties(python_bundle)
             shell_type = self.detect_shell()
             shell_config = self.get_shell_config(shell_type)
-            env_var = "CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE"
-            already_in_shell = False
-            if os.path.exists(shell_config):
-                with open(shell_config, 'r') as f:
-                    already_in_shell = (
-                        f'export {env_var}="{python_bundle}"'
-                        in f.read()
-                    )
-            self.add_to_shell_config(
-                env_var,
+            shell_changed = self.add_to_shell_config(
+                "CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE",
                 python_bundle,
                 shell_config,
             )
-            pre_bootstrap = props_changed or not already_in_shell
+            reauth_changed = self._ensure_gcloud_reauth_trust(
+                python_bundle, shell_config
+            )
+            pre_bootstrap = props_changed or shell_changed or reauth_changed
 
         if not self.command_exists('gcloud'):
             self.print_info("gcloud not found, skipping gcloud setup")
@@ -3439,6 +3654,8 @@ class FumitmPython:
             needs_setup = True
 
         if not needs_setup:
+            if pre_bootstrap and self.is_install_mode():
+                return ToolResult('gcloud', 'configured', 'Configured gcloud trust environment')
             return ToolResult('gcloud', 'already_ok', 'gcloud certificate already configured')
 
         self.print_info("Configuring gcloud certificate...")
@@ -4061,6 +4278,21 @@ class FumitmPython:
             return ToolResult('dbeaver', 'configured', 'Certificate added to DBeaver keystore')
         return ToolResult('dbeaver', 'failed', 'Failed to add certificate (may require sudo)')
     
+    def _last_active_wgetrc_ca(self, content):
+        """Return the path from the last active ca_certificate= line, or None.
+
+        wget honors the last directive, so the trust check must look at the final
+        non-commented ca_certificate= entry, not the first.
+        """
+        found = None
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped.startswith('#'):
+                continue
+            if stripped.startswith('ca_certificate='):
+                found = stripped.split('=', 1)[1].strip()
+        return found
+
     def setup_wget_cert(self):
         """Setup wget certificate."""
         if not self.command_exists('wget'):
@@ -4074,67 +4306,56 @@ class FumitmPython:
             return ToolResult('wget', 'already_ok', 'Works via system trust store')
 
         wgetrc_path = os.path.expanduser("~/.wgetrc")
-        config_line = f"ca_certificate={self.cert_path}"
+        wget_bundle = os.path.join(self.bundle_dir, "wget/ca-bundle.pem")
+        config_line = f"ca_certificate={wget_bundle}"
 
+        original = ''
         if os.path.exists(wgetrc_path):
             with open(wgetrc_path, 'r') as f:
-                content = f.read()
+                original = f.read()
 
-            if "ca_certificate=" in content:
-                # Check if it's already set to our certificate
-                if self.cert_path in content:
-                    return ToolResult('wget', 'already_ok', 'wget certificate already configured')
+        already_ok = (
+            self._last_active_wgetrc_ca(original) == wget_bundle
+            and os.path.exists(wget_bundle)
+            and self._all_roots_present_in_file(wget_bundle)
+        )
+        if already_ok:
+            return ToolResult('wget', 'already_ok', 'wget certificate already configured')
 
-                self.print_info("Configuring wget certificate...")
-                self.print_warn(f"wget ca_certificate is already set in {wgetrc_path}")
-
-                # Find current setting
-                for line in content.splitlines():
-                    if line.strip().startswith("ca_certificate="):
-                        self.print_info(f"Current setting: {line.strip()}")
-                        break
-
-                if not self.is_install_mode():
-                    self.print_action(f"Would ask to update the ca_certificate in {wgetrc_path}")
-                    self.print_action(f"Would set: {config_line}")
-                    return ToolResult('wget', 'skipped', 'Dry run')
-                else:
-                    response = self._prompt("Do you want to update it? (y/N) ")
-                    if response.lower() == 'y':
-                        # Comment out old entries
-                        lines = content.splitlines()
-                        new_lines = []
-                        for line in lines:
-                            if line.strip().startswith("ca_certificate="):
-                                new_lines.append(f"#{line}")
-                            else:
-                                new_lines.append(line)
-
-                        # Add new entry
-                        new_lines.append(config_line)
-
-                        # Write back
-                        with open(wgetrc_path + '.bak', 'w') as f:
-                            f.write(content)
-                        with open(wgetrc_path, 'w') as f:
-                            f.write('\n'.join(new_lines) + '\n')
-
-                        self.print_info(f"Updated wget configuration in {wgetrc_path}")
-                        return ToolResult('wget', 'configured', 'Updated wget configuration')
-                    return ToolResult('wget', 'skipped', 'User declined')
-
-        # File doesn't exist or doesn't have ca_certificate
         self.print_info("Configuring wget certificate...")
-
         if not self.is_install_mode():
-            self.print_action(f"Would add to {wgetrc_path}: {config_line}")
+            self.print_action(f"Would create wget CA bundle at {wget_bundle}")
+            self.print_action(f"Would set in {wgetrc_path}: {config_line}")
             return ToolResult('wget', 'skipped', 'Dry run')
-        else:
-            self.print_info(f"Adding configuration to {wgetrc_path}")
-            with open(wgetrc_path, 'a') as f:
-                f.write(f"\n{config_line}\n")
-            self.print_info("Added ca_certificate to wget configuration")
-            return ToolResult('wget', 'configured', 'Added ca_certificate to wget configuration')
+
+        # Build the both-roots bundle (primary + every supplemental root) so wget
+        # trusts whichever proxy intercepts the connection.
+        self._safe_makedirs(os.path.dirname(wget_bundle))
+        self.create_bundle_with_system_certs(wget_bundle)
+        self._append_all_proxy_roots(wget_bundle)
+
+        # Deterministically rewrite ~/.wgetrc: drop any active ca_certificate
+        # directives and append ours last so wget honors the both-roots bundle.
+        kept = [
+            line for line in original.splitlines()
+            if not line.strip().startswith('ca_certificate=')
+        ]
+        while kept and kept[-1].strip() == '':
+            kept.pop()
+        new = (('\n'.join(kept) + '\n\n') if kept else '') + config_line + '\n'
+
+        if wgetrc_path not in self._backed_up_shell_configs:
+            if os.path.exists(wgetrc_path):
+                with open(wgetrc_path + '.bak', 'w') as f:
+                    f.write(original)
+                self._fix_ownership(wgetrc_path + '.bak')
+            self._backed_up_shell_configs.add(wgetrc_path)
+
+        with open(wgetrc_path, 'w') as f:
+            f.write(new)
+        self._fix_ownership(wgetrc_path)
+        self.print_info(f"Configured wget ca_certificate to: {wget_bundle}")
+        return ToolResult('wget', 'configured', 'Configured wget ca_certificate')
     
     def _podman_vm_running(self):
         """Check whether a Podman machine is currently running."""
@@ -5578,35 +5799,29 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             # First, verify if wget can actually connect
             verify_result = self.verify_connection("wget")
 
+            wgetrc_path = os.path.expanduser("~/.wgetrc")
+            configured_ca = None
+            if os.path.exists(wgetrc_path):
+                with open(wgetrc_path, 'r') as f:
+                    configured_ca = self._last_active_wgetrc_ca(f.read())
+            has_all_roots = bool(
+                configured_ca and os.path.exists(configured_ca)
+                and self._status_roots_present(temp_warp_cert, configured_ca)
+            )
+
             if verify_result == "WORKING":
                 self.print_info("  ✓ wget can connect through proxy")
-
-                # Check config status (informational only)
-                wgetrc_path = os.path.expanduser("~/.wgetrc")
-                if os.path.exists(wgetrc_path):
-                    with open(wgetrc_path, 'r') as f:
-                        content = f.read()
-                    if "ca_certificate=" in content and self.cert_path in content:
-                        self.print_info("  ✓ wget configured with proxy certificate")
-                    else:
-                        self.print_info("  - Using system certificate trust (no custom CA needed)")
+                if has_all_roots:
+                    self.print_info("  ✓ wget configured with proxy certificate")
                 else:
                     self.print_info("  - Using system certificate trust (no custom CA needed)")
             else:
                 # wget doesn't work, check configuration
-                wgetrc_path = os.path.expanduser("~/.wgetrc")
-                if os.path.exists(wgetrc_path):
-                    with open(wgetrc_path, 'r') as f:
-                        content = f.read()
-                    if "ca_certificate=" in content and self.cert_path in content:
-                        self.print_warn("  ✗ wget configured but connection test failed")
-                        has_issues = True
-                    else:
-                        self.print_warn("  ✗ wget not configured with proxy certificate")
-                        has_issues = True
+                if has_all_roots:
+                    self.print_warn("  ✗ wget configured but connection test failed")
                 else:
-                    self.print_warn("  ✗ wget not configured")
-                    has_issues = True
+                    self.print_warn("  ✗ wget not configured with proxy certificate")
+                has_issues = True
         else:
             self.print_info("  - wget not installed")
         return has_issues
@@ -5623,7 +5838,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             cert_path = os.path.join(docker_certs_dir, f"{self.provider['container_cert_name']}.crt")
 
             if os.path.exists(cert_path):
-                if self._status_roots_present(temp_warp_cert, cert_path, likely=True):
+                if self._status_container_certs_present(temp_warp_cert, docker_certs_dir):
                     self.print_info("  ✓ Certificate installed in ~/.docker/certs.d/ (persistent)")
                 else:
                     self.print_warn("  ✗ Certificate in ~/.docker/certs.d/ is outdated")
@@ -5665,7 +5880,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             cert_path = os.path.join(docker_certs_dir, f"{self.provider['container_cert_name']}.crt")
 
             if os.path.exists(cert_path):
-                if self._status_roots_present(temp_warp_cert, cert_path, likely=True):
+                if self._status_container_certs_present(temp_warp_cert, docker_certs_dir):
                     self.print_info("  ✓ Certificate installed in ~/.docker/certs.d/ (persistent)")
                 else:
                     self.print_warn("  ✗ Certificate in ~/.docker/certs.d/ is outdated")
@@ -5705,7 +5920,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             )
 
             if os.path.exists(cert_path):
-                if self._status_roots_present(temp_warp_cert, cert_path, likely=True):
+                if self._status_container_certs_present(temp_warp_cert, docker_certs_dir):
                     self.print_info("  ✓ Certificate installed in ~/.docker/certs.d/ (persistent)")
                 else:
                     self.print_warn("  ✗ Certificate in ~/.docker/certs.d/ is outdated")
@@ -5755,7 +5970,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             cert_path = os.path.join(docker_certs_dir, f"{self.provider['container_cert_name']}.crt")
 
             if os.path.exists(cert_path):
-                if self._status_roots_present(temp_warp_cert, cert_path, likely=True):
+                if self._status_container_certs_present(temp_warp_cert, docker_certs_dir):
                     self.print_info("  ✓ Certificate installed in ~/.docker/certs.d/ (persistent)")
                 else:
                     self.print_warn("  ✗ Certificate in ~/.docker/certs.d/ is outdated")
@@ -5999,7 +6214,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             docker_certs_dir = os.path.expanduser("~/.docker/certs.d")
             cert_path = os.path.join(docker_certs_dir, f"{self.provider['container_cert_name']}.crt")
             if os.path.exists(cert_path):
-                if self._container_certs_present(docker_certs_dir):
+                if self._status_container_certs_present(temp_warp_cert, docker_certs_dir):
                     self.print_info(f"  ✓ Certificate installed in {docker_certs_dir}")
                     self.print_info("    (Used by: Docker, OrbStack, Colima, Podman, Rancher Desktop, Lima)")
                     self._print_docker_build_hint()
@@ -6354,7 +6569,12 @@ def main():
                         help='MITM proxy provider (default: auto-detect)')
     parser.add_argument('--with-aikido', action='store_true',
                         help='Force-add the Aikido Endpoint Protection root CA to all '
-                             'bundles even if it is not auto-detected')
+                             'bundles even if it is not auto-detected. On hosts with no '
+                             'live Aikido agent, supply the root via --aikido-cert or a '
+                             'previously saved ~/.aikido-ca.pem')
+    parser.add_argument('--aikido-cert', metavar='PATH',
+                        help='Path to a PEM file containing the Aikido root CA, used as '
+                             'the preferred source for --with-aikido on no-agent images')
     parser.add_argument('--no-aikido', action='store_true',
                         help='Do not add the Aikido root CA even if Aikido is detected')
     parser.add_argument('--yes', '-y', action='store_true',
@@ -6433,6 +6653,8 @@ def main():
 
     if args.with_aikido and args.no_aikido:
         parser.error('--with-aikido and --no-aikido are mutually exclusive')
+    if args.aikido_cert and args.no_aikido:
+        parser.error('--aikido-cert cannot be combined with --no-aikido')
 
     mode = 'install' if args.fix else 'status'
 
@@ -6455,6 +6677,7 @@ def main():
         run_as_user=args.run_as_user,
         with_aikido=args.with_aikido,
         no_aikido=args.no_aikido,
+        aikido_cert_file=args.aikido_cert,
     )
     exit_code = fumitm_instance.main()
     sys.exit(exit_code)

--- a/fumitm.py
+++ b/fumitm.py
@@ -488,6 +488,19 @@ class FumitmPython:
                 return config['name']
         return None
 
+    def _is_vendor_injected_bundle(self, path):
+        """Return True if path lives under a supplemental-root vendor's own directory.
+
+        Such a bundle (e.g. Aikido's combined PEM) is maintained and env-injected
+        by the vendor at runtime. fumitm must not adopt, append to, or relocate
+        it; it manages its own bundle instead.
+        """
+        for descriptor in SUPPLEMENTAL_ROOTS.values():
+            support_dir = descriptor.get('support_dir')
+            if support_dir and path.startswith(support_dir):
+                return True
+        return False
+
     def _detect_warp(self):
         """Return True if Cloudflare WARP appears to be installed."""
         return shutil.which('warp-cli') is not None
@@ -3099,7 +3112,20 @@ class FumitmPython:
         needs_setup = False
 
         requests_ca_bundle = os.environ.get('REQUESTS_CA_BUNDLE', '')
-        
+
+        # A supplemental-root vendor (e.g. Aikido) may export REQUESTS_CA_BUNDLE
+        # at its own maintained, root-owned bundle. fumitm must not adopt or
+        # relocate that file: it is the vendor's to manage and would be reverted
+        # on the vendor's next update. Ignore it and fall through to building
+        # fumitm's own ~/.python-ca-bundle.pem with every root, which the
+        # vendor-untouched SSL_CERT_FILE then points at.
+        if requests_ca_bundle and self._is_vendor_injected_bundle(requests_ca_bundle):
+            self.print_info(
+                f"Ignoring vendor-injected REQUESTS_CA_BUNDLE ({requests_ca_bundle}); "
+                f"using fumitm-managed bundle {python_bundle}"
+            )
+            requests_ca_bundle = ''
+
         if requests_ca_bundle:
             if os.path.exists(requests_ca_bundle):
                 # Check if we can write to the file

--- a/test_suite/helpers.py
+++ b/test_suite/helpers.py
@@ -197,11 +197,14 @@ class FumitmTestCase:
                                selected_tools=None, provider='warp',
                                auto_yes=False, no_color=False,
                                headless=False, skip_update_check=False,
-                               run_as_user=None, **kwargs):
+                               run_as_user=None, no_aikido=True, **kwargs):
         """Create a FumitmPython instance with proper mocking.
 
         Defaults to provider='warp' to skip auto-detection, which would
         otherwise trigger subprocess calls (pgrep) that consume mock responses.
+        Defaults to no_aikido=True so supplemental-root detection does not run
+        against the host (which may actually have Aikido installed); tests that
+        exercise Aikido pass no_aikido=False or with_aikido=True explicitly.
         """
         import fumitm
         with patch('platform.system', return_value='Darwin'):
@@ -215,6 +218,7 @@ class FumitmTestCase:
                 headless=headless,
                 skip_update_check=skip_update_check,
                 run_as_user=run_as_user,
+                no_aikido=no_aikido,
                 **kwargs,
             )
 

--- a/test_suite/mock_data.py
+++ b/test_suite/mock_data.py
@@ -160,6 +160,31 @@ NETSKOPE_CERT_PATHS_LINUX = ['/opt/netskope/stagent/data/nscacert.pem']
 # Netskope mock certificate (reuses the same cert format for testing)
 MOCK_NETSKOPE_CERTIFICATE = MOCK_CERTIFICATE
 
+# Aikido Endpoint Protection (supplemental root CA) test data.
+AIKIDO_SUPPORT_DIR = '/Library/Application Support/AikidoSecurity/'
+AIKIDO_COMBINED_PEM = (
+    '/Library/Application Support/AikidoSecurity/'
+    'EndpointProtection/run/endpoint-protection-pip-combined-ca.pem'
+)
+# The keychain/subject CN starts with this prefix; the org suffix varies.
+AIKIDO_ROOT_CN = 'Aikido Endpoint Protection Root CA - org-101951'
+# The interception intermediate has an ephemeral hex CN that must be rejected.
+AIKIDO_INTERMEDIATE_CN = '9679a1b2c3d4e5f600112233445566778899aabbccddeeff00112233679dd'
+
+# Distinct body markers let mocked openssl map a PEM block back to its subject.
+MOCK_AIKIDO_ROOT_CERT = """-----BEGIN CERTIFICATE-----
+AIKIDOROOTMIIEjTCCA3WgAwIBAgISA2Q1Q5XQHgYE8xhA9PkyCgypMA0GCSqGSIb3
+DQEBCwUAMDIxCzAJBgNVBAYTAlVTAIKIDOROOTBODYAAAAAAAAAAAAAAAAAAAAAAAA
+-----END CERTIFICATE-----"""
+
+MOCK_AIKIDO_INTERMEDIATE_CERT = """-----BEGIN CERTIFICATE-----
+AIKIDOINTERMEDIATEMIIEjTCCA3WgAwIBAgISA2Q1Q5XQHgYE8xhA9PkyCgypMA0G
+CSqGSIb3DQEBCwUAMDIxCzAJBgNVBAYTAlVTAIKIDOINTERMEDIATEBODYAAAAAAAA
+-----END CERTIFICATE-----"""
+
+# Concatenation as returned by `security find-certificate -a` or the combined PEM.
+MOCK_AIKIDO_KEYCHAIN_OUTPUT = MOCK_AIKIDO_ROOT_CERT + "\n" + MOCK_AIKIDO_INTERMEDIATE_CERT
+
 # Shell detection outputs
 SHELL_PS_BASH = "/bin/bash"
 SHELL_PS_ZSH = "/bin/zsh"

--- a/test_suite/test_aikido_root.py
+++ b/test_suite/test_aikido_root.py
@@ -1,0 +1,253 @@
+"""Tests for Aikido supplemental root-CA support.
+
+Aikido Endpoint Protection performs *selective* TLS interception on top of a
+primary provider (WARP/Netskope). fumitm detects it and adds the Aikido root to
+every managed bundle/keystore/VM alongside the primary root, never replacing it.
+These tests cover detection, root extraction (root kept, ephemeral intermediate
+rejected), additive bundle assembly, idempotency, and the absent-Aikido no-op.
+"""
+
+from unittest.mock import MagicMock, mock_open, patch
+
+import mock_data
+from helpers import FumitmTestCase
+
+
+class TestAikidoDetection(FumitmTestCase):
+    """Tests for _detect_aikido() across each signal and the all-absent case."""
+
+    def _instance(self):
+        # no_aikido=True keeps construction from touching the host; we call the
+        # detection method directly under explicit patches below.
+        return self.create_fumitm_instance(provider='warp', no_aikido=True)
+
+    def test_detected_via_support_dir(self):
+        inst = self._instance()
+        with patch('fumitm.os.path.isdir', return_value=True):
+            assert inst._detect_aikido() is True
+
+    def test_detected_via_combined_pem(self):
+        inst = self._instance()
+        with patch('fumitm.os.path.isdir', return_value=False), \
+             patch('fumitm.os.path.exists',
+                   side_effect=lambda p: p == mock_data.AIKIDO_COMBINED_PEM):
+            assert inst._detect_aikido() is True
+
+    def test_detected_via_keychain(self):
+        inst = self._instance()
+        hit = MagicMock(returncode=0, stdout='cert')
+        with patch('fumitm.os.path.isdir', return_value=False), \
+             patch('fumitm.os.path.exists', return_value=False), \
+             patch('fumitm.platform.system', return_value='Darwin'), \
+             patch('fumitm.subprocess.run', return_value=hit):
+            assert inst._detect_aikido() is True
+
+    def test_not_detected_when_all_absent(self):
+        inst = self._instance()
+        miss = MagicMock(returncode=1, stdout='')
+        with patch('fumitm.os.path.isdir', return_value=False), \
+             patch('fumitm.os.path.exists', return_value=False), \
+             patch('fumitm.platform.system', return_value='Darwin'), \
+             patch('fumitm.subprocess.run', return_value=miss):
+            assert inst._detect_aikido() is False
+
+    def test_linux_skips_keychain(self):
+        """On Linux only the filesystem signals are consulted (no keychain)."""
+        inst = self._instance()
+        with patch('fumitm.os.path.isdir', return_value=False), \
+             patch('fumitm.os.path.exists', return_value=False), \
+             patch('fumitm.platform.system', return_value='Linux'), \
+             patch('fumitm.subprocess.run') as mock_run:
+            assert inst._detect_aikido() is False
+            mock_run.assert_not_called()
+
+
+def _fake_subject(block):
+    """Map a mock PEM block to its openssl subject line by body marker."""
+    if 'AIKIDOROOT' in block:
+        return f'subject=CN={mock_data.AIKIDO_ROOT_CN}'
+    if 'AIKIDOINTERMEDIATE' in block:
+        return f'subject=CN={mock_data.AIKIDO_INTERMEDIATE_CN}'
+    return None
+
+
+class TestAikidoCnFilter(FumitmTestCase):
+    """Tests that the CN-prefix filter keeps the root and rejects the intermediate."""
+
+    def test_keeps_root_rejects_intermediate(self):
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True)
+        with patch.object(inst, '_openssl_subject', side_effect=_fake_subject):
+            kept = inst._filter_certs_by_cn_prefix(
+                mock_data.MOCK_AIKIDO_KEYCHAIN_OUTPUT,
+                'Aikido Endpoint Protection Root CA',
+            )
+        assert len(kept) == 1
+        assert 'AIKIDOROOT' in kept[0]
+        assert 'AIKIDOINTERMEDIATE' not in kept[0]
+
+    def test_subject_common_name_parses_all_forms(self):
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True)
+        # RFC 2253, OpenSSL 3 spaced, and LibreSSL slash forms all parse.
+        assert inst._subject_common_name('subject=CN=Foo Bar,O=Org') == 'Foo Bar'
+        assert inst._subject_common_name('subject=CN = Foo Bar, O = Org') == 'Foo Bar'
+        assert inst._subject_common_name('subject= /CN=Foo Bar/O=Org') == 'Foo Bar'
+        assert inst._subject_common_name('subject=O=Org') is None
+
+
+class TestAikidoRootExtraction(FumitmTestCase):
+    """Tests for _get_aikido_root_cert() keychain and combined-PEM paths."""
+
+    def test_keychain_returns_only_root(self):
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True)
+        keychain = MagicMock(returncode=0, stdout=mock_data.MOCK_AIKIDO_KEYCHAIN_OUTPUT)
+        with patch('fumitm.platform.system', return_value='Darwin'), \
+             patch('fumitm.subprocess.run', return_value=keychain), \
+             patch.object(inst, '_openssl_subject', side_effect=_fake_subject):
+            result = inst._get_aikido_root_cert()
+        assert result is not None
+        assert 'AIKIDOROOT' in result
+        assert 'AIKIDOINTERMEDIATE' not in result
+
+    def test_combined_pem_fallback(self):
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True)
+        # Keychain misses; the combined PEM on disk provides the root.
+        miss = MagicMock(returncode=1, stdout='')
+        with patch('fumitm.platform.system', return_value='Darwin'), \
+             patch('fumitm.subprocess.run', return_value=miss), \
+             patch('fumitm.os.path.exists', return_value=True), \
+             patch('builtins.open',
+                   mock_open(read_data=mock_data.MOCK_AIKIDO_KEYCHAIN_OUTPUT)), \
+             patch.object(inst, '_openssl_subject', side_effect=_fake_subject):
+            result = inst._get_aikido_root_cert()
+        assert result is not None
+        assert 'AIKIDOROOT' in result
+        assert 'AIKIDOINTERMEDIATE' not in result
+
+    def test_returns_none_when_unavailable(self):
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True)
+        miss = MagicMock(returncode=1, stdout='')
+        with patch('fumitm.platform.system', return_value='Darwin'), \
+             patch('fumitm.subprocess.run', return_value=miss), \
+             patch('fumitm.os.path.exists', return_value=False):
+            assert inst._get_aikido_root_cert() is None
+
+
+def _aikido_instance_with_root(root_path):
+    """Build a WARP instance carrying a materialized Aikido supplemental root."""
+    inst = FumitmTestCase.create_fumitm_instance(provider='warp', no_aikido=True)
+    inst.extra_roots = [{
+        'key': 'aikido',
+        'name': 'Aikido Endpoint Protection',
+        'short_name': 'Aikido',
+        'keytool_alias': 'aikido-root',
+        'container_cert_name': 'aikido',
+        'path': str(root_path),
+    }]
+    return inst
+
+
+class TestAikidoBundleAssembly(FumitmTestCase):
+    """Bundle/keystore/container accessors include both roots, additively."""
+
+    def test_all_proxy_roots_appended_without_duplicates(self, tmp_path):
+        primary = tmp_path / 'primary.pem'
+        primary.write_text(mock_data.MOCK_CERTIFICATE)
+        aikido = tmp_path / 'aikido.pem'
+        aikido.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+        target = tmp_path / 'bundle.pem'
+        target.write_text('')
+
+        inst = _aikido_instance_with_root(aikido)
+        inst.cert_path = str(primary)
+
+        assert inst._append_all_proxy_roots(str(target)) is True
+        body = target.read_text()
+        assert mock_data.MOCK_CERTIFICATE.strip() in body
+        assert mock_data.MOCK_AIKIDO_ROOT_CERT.strip() in body
+        # Exactly two certificate blocks: primary + Aikido, no public roots here.
+        assert body.count('-----BEGIN CERTIFICATE-----') == 2
+
+        # Second pass is idempotent: no duplicate appends.
+        inst._append_all_proxy_roots(str(target))
+        assert target.read_text().count('-----BEGIN CERTIFICATE-----') == 2
+
+    def test_all_proxy_root_paths_includes_both(self, tmp_path):
+        aikido = tmp_path / 'aikido.pem'
+        aikido.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+        inst = _aikido_instance_with_root(aikido)
+        inst.cert_path = '/home/user/.cloudflare-ca.pem'
+        paths = inst._all_proxy_root_paths()
+        assert paths == ['/home/user/.cloudflare-ca.pem', str(aikido)]
+
+    def test_root_aliases_and_container_certs(self, tmp_path):
+        aikido = tmp_path / 'aikido.pem'
+        aikido.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+        inst = _aikido_instance_with_root(aikido)
+        aliases = dict(inst._all_root_aliases())
+        assert aliases['cloudflare-zerotrust'] == inst.cert_path
+        assert aliases['aikido-root'] == str(aikido)
+        names = dict(inst._all_container_certs())
+        assert names['cloudflare-warp'] == inst.cert_path
+        assert names['aikido'] == str(aikido)
+
+
+class TestAikidoIdempotency(FumitmTestCase):
+    """A bundle missing the Aikido root is incomplete; with both it is healthy."""
+
+    def test_missing_aikido_flagged_incomplete(self, tmp_path):
+        primary = tmp_path / 'primary.pem'
+        primary.write_text(mock_data.MOCK_CERTIFICATE)
+        aikido = tmp_path / 'aikido.pem'
+        aikido.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+
+        only_primary = tmp_path / 'only_primary.pem'
+        only_primary.write_text(mock_data.MOCK_CERTIFICATE)
+        both = tmp_path / 'both.pem'
+        both.write_text(mock_data.MOCK_CERTIFICATE + '\n' + mock_data.MOCK_AIKIDO_ROOT_CERT)
+
+        inst = _aikido_instance_with_root(aikido)
+        inst.cert_path = str(primary)
+
+        assert inst._all_roots_present_in_file(str(only_primary)) is False
+        assert inst._all_roots_present_in_file(str(both)) is True
+
+
+class TestAikidoAbsentNoOp(FumitmTestCase):
+    """With Aikido absent, accessors reduce to the single primary root."""
+
+    def test_no_extra_roots(self):
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True)
+        assert inst.extra_roots == []
+        assert inst._all_proxy_root_paths() == [inst.cert_path]
+        assert inst._all_root_aliases() == [('cloudflare-zerotrust', inst.cert_path)]
+        assert inst._all_container_certs() == [('cloudflare-warp', inst.cert_path)]
+
+    def test_append_matches_single_root(self, tmp_path):
+        primary = tmp_path / 'primary.pem'
+        primary.write_text(mock_data.MOCK_CERTIFICATE)
+        target = tmp_path / 'bundle.pem'
+        target.write_text('')
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True)
+        inst.cert_path = str(primary)
+        inst._append_all_proxy_roots(str(target))
+        assert target.read_text().count('BEGIN CERTIFICATE') == 1
+
+
+class TestAikidoResolution(FumitmTestCase):
+    """--with-aikido forces on; --no-aikido forces off; detection gates the rest."""
+
+    def test_with_aikido_forces_on_without_detection(self):
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=False,
+                                           with_aikido=True)
+        assert any(e['key'] == 'aikido' for e in inst.extra_roots)
+
+    def test_no_aikido_forces_off_even_when_detected(self):
+        # Construct with no_aikido=True; detection must not be consulted.
+        with patch('fumitm.FumitmPython._detect_aikido', return_value=True):
+            inst = self.create_fumitm_instance(provider='warp', no_aikido=True)
+        assert inst.extra_roots == []
+
+    def test_auto_detect_populates_extra_roots(self):
+        with patch('fumitm.FumitmPython._detect_aikido', return_value=True):
+            inst = self.create_fumitm_instance(provider='warp', no_aikido=False)
+        assert any(e['key'] == 'aikido' for e in inst.extra_roots)

--- a/test_suite/test_aikido_root.py
+++ b/test_suite/test_aikido_root.py
@@ -233,6 +233,59 @@ class TestAikidoAbsentNoOp(FumitmTestCase):
         assert target.read_text().count('BEGIN CERTIFICATE') == 1
 
 
+class TestVendorInjectedBundle(FumitmTestCase):
+    """fumitm ignores a vendor-injected REQUESTS_CA_BUNDLE and builds its own."""
+
+    def test_is_vendor_injected_bundle(self):
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True)
+        assert inst._is_vendor_injected_bundle(mock_data.AIKIDO_COMBINED_PEM) is True
+        assert inst._is_vendor_injected_bundle(
+            mock_data.AIKIDO_SUPPORT_DIR + 'anything.pem') is True
+        assert inst._is_vendor_injected_bundle('/Users/x/.python-ca-bundle.pem') is False
+
+    def test_setup_python_ignores_vendor_bundle_and_includes_all_roots(
+            self, tmp_path, monkeypatch):
+        primary = tmp_path / 'primary.pem'
+        primary.write_text(mock_data.MOCK_CERTIFICATE)
+        aikido = tmp_path / 'aikido.pem'
+        aikido.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+        home = tmp_path / 'home'
+        home.mkdir()
+
+        monkeypatch.setenv('HOME', str(home))
+        # Aikido injects its own unwritable combined PEM at runtime.
+        monkeypatch.setenv('REQUESTS_CA_BUNDLE', mock_data.AIKIDO_COMBINED_PEM)
+        monkeypatch.delenv('SSL_CERT_FILE', raising=False)
+        monkeypatch.delenv('CURL_CA_BUNDLE', raising=False)
+
+        inst = _aikido_instance_with_root(aikido)
+        inst.mode = 'install'
+        inst.cert_path = str(primary)
+
+        def seed_system_certs(path):
+            with open(path, 'w') as f:
+                f.write('-----BEGIN CERTIFICATE-----\nSYSTEMROOT\n-----END CERTIFICATE-----\n')
+            return True
+
+        with patch.object(inst, 'command_exists',
+                          side_effect=lambda c: c == 'python3'), \
+             patch.object(inst, 'detect_shell', return_value='zsh'), \
+             patch.object(inst, 'get_shell_config', return_value=str(home / '.zshrc')), \
+             patch.object(inst, 'add_to_shell_config'), \
+             patch.object(inst, 'create_bundle_with_system_certs',
+                          side_effect=seed_system_certs):
+            result = inst.setup_python_cert()
+
+        bundle = home / '.python-ca-bundle.pem'
+        assert bundle.exists(), "fumitm-managed bundle was not created"
+        body = bundle.read_text()
+        # Public roots (seeded), primary provider root, and Aikido root all present.
+        assert 'SYSTEMROOT' in body
+        assert mock_data.MOCK_CERTIFICATE.strip() in body
+        assert mock_data.MOCK_AIKIDO_ROOT_CERT.strip() in body
+        assert result.status == 'configured'
+
+
 class TestAikidoResolution(FumitmTestCase):
     """--with-aikido forces on; --no-aikido forces off; detection gates the rest."""
 

--- a/test_suite/test_aikido_root.py
+++ b/test_suite/test_aikido_root.py
@@ -304,3 +304,443 @@ class TestAikidoResolution(FumitmTestCase):
         with patch('fumitm.FumitmPython._detect_aikido', return_value=True):
             inst = self.create_fumitm_instance(provider='warp', no_aikido=False)
         assert any(e['key'] == 'aikido' for e in inst.extra_roots)
+
+    def test_explicit_cert_file_implies_aikido_active(self, tmp_path):
+        """--aikido-cert forces Aikido on without auto-detection."""
+        cert = tmp_path / 'aikido-root.pem'
+        cert.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+        with patch('fumitm.FumitmPython._detect_aikido', return_value=False):
+            inst = self.create_fumitm_instance(provider='warp', no_aikido=False,
+                                               aikido_cert_file=str(cert))
+        assert any(e['key'] == 'aikido' for e in inst.extra_roots)
+
+
+class TestAikidoForcedSources(FumitmTestCase):
+    """--with-aikido must work without a live agent: explicit file or persisted root."""
+
+    def test_explicit_cert_file_used_when_agent_absent(self, tmp_path):
+        """An operator-supplied PEM is the preferred source and bypasses the agent."""
+        cert = tmp_path / 'aikido-root.pem'
+        cert.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True,
+                                           aikido_cert_file=str(cert))
+        # Explicit source is consulted before keychain/PEM, so the no-agent host
+        # (Linux, no keychain) still yields the root.
+        with patch('fumitm.platform.system', return_value='Linux'), \
+             patch.object(inst, '_openssl_subject', side_effect=_fake_subject):
+            result = inst._get_aikido_root_cert()
+        assert result is not None
+        assert 'AIKIDOROOT' in result
+        assert 'AIKIDOINTERMEDIATE' not in result
+
+    def test_persisted_root_used_when_agent_absent(self, tmp_path, monkeypatch):
+        """A root saved by an earlier run is used when keychain and PEM are gone."""
+        monkeypatch.setenv('HOME', str(tmp_path))
+        persisted = tmp_path / '.aikido-ca.pem'
+        persisted.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True)
+        miss = MagicMock(returncode=1, stdout='')
+        # Keychain misses and the combined PEM is treated as absent; only the
+        # persisted ~/.aikido-ca.pem remains.
+        with patch('fumitm.platform.system', return_value='Darwin'), \
+             patch('fumitm.subprocess.run', return_value=miss), \
+             patch('fumitm.os.path.exists', side_effect=lambda p: p == str(persisted)), \
+             patch.object(inst, '_openssl_subject', side_effect=_fake_subject):
+            result = inst._get_aikido_root_cert()
+        assert result is not None
+        assert 'AIKIDOROOT' in result
+
+    def test_explicit_cert_with_no_matching_root_falls_through(self, tmp_path, monkeypatch):
+        """An explicit file lacking an Aikido root warns and yields nothing usable."""
+        monkeypatch.setenv('HOME', str(tmp_path))
+        cert = tmp_path / 'unrelated.pem'
+        cert.write_text(mock_data.MOCK_CERTIFICATE)
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True,
+                                           aikido_cert_file=str(cert))
+        miss = MagicMock(returncode=1, stdout='')
+        with patch('fumitm.platform.system', return_value='Darwin'), \
+             patch('fumitm.subprocess.run', return_value=miss), \
+             patch('fumitm.os.path.exists', side_effect=lambda p: p == str(cert)), \
+             patch.object(inst, '_openssl_subject', side_effect=_fake_subject):
+            # The primary cert's CN does not start with the Aikido prefix, so the
+            # filter drops it and no other source is available.
+            assert inst._get_aikido_root_cert() is None
+
+
+class TestAikidoContainerStatus(FumitmTestCase):
+    """Container status checks each root in its own split file, not all in one."""
+
+    def test_split_files_checked_separately(self, tmp_path):
+        certs_dir = tmp_path / 'certs.d'
+        certs_dir.mkdir()
+        primary_temp = tmp_path / 'primary_temp.pem'
+        primary_temp.write_text(mock_data.MOCK_CERTIFICATE)
+        aikido = tmp_path / 'aikido.pem'
+        aikido.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+        inst = _aikido_instance_with_root(aikido)
+
+        # Only the primary split file is present: the supplemental root is still
+        # missing, so the persistent location is incomplete.
+        (certs_dir / 'cloudflare-warp.crt').write_text(mock_data.MOCK_CERTIFICATE)
+        assert inst._status_container_certs_present(
+            str(primary_temp), str(certs_dir)) is False
+
+        # Adding the Aikido split file completes it.
+        (certs_dir / 'aikido.crt').write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+        assert inst._status_container_certs_present(
+            str(primary_temp), str(certs_dir)) is True
+
+    def test_reduces_to_single_root_without_aikido(self, tmp_path):
+        certs_dir = tmp_path / 'certs.d'
+        certs_dir.mkdir()
+        primary_temp = tmp_path / 'primary_temp.pem'
+        primary_temp.write_text(mock_data.MOCK_CERTIFICATE)
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True)
+
+        assert inst._status_container_certs_present(
+            str(primary_temp), str(certs_dir)) is False
+        (certs_dir / 'cloudflare-warp.crt').write_text(mock_data.MOCK_CERTIFICATE)
+        assert inst._status_container_certs_present(
+            str(primary_temp), str(certs_dir)) is True
+
+
+class TestAikidoBrewPostinstall(FumitmTestCase):
+    """brew regenerates from the keychain; supplemental roots are appended directly."""
+
+    def test_appends_supplemental_root_brew_omitted(self, tmp_path):
+        primary = tmp_path / 'primary.pem'
+        primary.write_text(mock_data.MOCK_CERTIFICATE)
+        aikido = tmp_path / 'aikido.pem'
+        aikido.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+        # brew rebuilds the bundle from the keychain and includes only the
+        # primary provider root (Aikido lives in the combined PEM, not the keychain).
+        bundle = tmp_path / 'cert.pem'
+        bundle.write_text(mock_data.MOCK_CERTIFICATE + '\n')
+
+        inst = _aikido_instance_with_root(aikido)
+        inst.cert_path = str(primary)
+        inst.mode = 'install'
+
+        ok = MagicMock(returncode=0, stdout='', stderr='')
+        with patch('fumitm.subprocess.run', return_value=ok):
+            result = inst._run_brew_postinstall(str(bundle))
+
+        assert result.status == 'configured'
+        body = bundle.read_text()
+        assert mock_data.MOCK_CERTIFICATE.strip() in body
+        assert mock_data.MOCK_AIKIDO_ROOT_CERT.strip() in body
+
+    def test_fails_when_primary_root_absent(self, tmp_path):
+        primary = tmp_path / 'primary.pem'
+        primary.write_text(mock_data.MOCK_CERTIFICATE)
+        # brew succeeds but the proxy CA is not in the keychain, so the bundle
+        # never gains the primary root.
+        bundle = tmp_path / 'cert.pem'
+        bundle.write_text('-----BEGIN CERTIFICATE-----\nOTHER\n-----END CERTIFICATE-----\n')
+
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True)
+        inst.cert_path = str(primary)
+        inst.mode = 'install'
+
+        ok = MagicMock(returncode=0, stdout='', stderr='')
+        with patch('fumitm.subprocess.run', return_value=ok):
+            result = inst._run_brew_postinstall(str(bundle))
+        assert result.status == 'failed'
+
+    def test_appends_provider_intermediate_brew_omitted(self, tmp_path):
+        # Netskope's cert_path is a combined root+intermediate PEM. brew rebuilds
+        # the bundle from the keychain, which holds only the root, so the
+        # intermediate is dropped. Because the root *was* sourced, this is not a
+        # keychain failure: the intermediate must be topped up, not reported as
+        # failed. The second block stands in for a provider intermediate.
+        combined = tmp_path / 'combined.pem'
+        combined.write_text(
+            mock_data.MOCK_CERTIFICATE + '\n'
+            + mock_data.MOCK_AIKIDO_INTERMEDIATE_CERT
+        )
+        bundle = tmp_path / 'cert.pem'
+        bundle.write_text(mock_data.MOCK_CERTIFICATE + '\n')
+
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True)
+        inst.cert_path = str(combined)
+        inst.mode = 'install'
+
+        ok = MagicMock(returncode=0, stdout='', stderr='')
+        with patch('fumitm.subprocess.run', return_value=ok):
+            result = inst._run_brew_postinstall(str(bundle))
+
+        assert result.status == 'configured'
+        body = bundle.read_text()
+        assert mock_data.MOCK_CERTIFICATE.strip() in body
+        assert mock_data.MOCK_AIKIDO_INTERMEDIATE_CERT.strip() in body
+
+
+def _seed_system_certs(path):
+    """Stand-in for create_bundle_with_system_certs: seed a public-root marker."""
+    with open(path, 'w') as f:
+        f.write('-----BEGIN CERTIFICATE-----\nSYSTEMROOT\n-----END CERTIFICATE-----\n')
+    return True
+
+
+class TestAikidoPythonTrustVars(FumitmTestCase):
+    """With Aikido active, setup_python_cert reclaims the vendor-set Python vars."""
+
+    def test_vendor_vars_exported_to_both_roots_bundle(self, tmp_path, monkeypatch):
+        home = tmp_path / 'home'
+        home.mkdir()
+        monkeypatch.setenv('HOME', str(home))
+        for var in ('REQUESTS_CA_BUNDLE', 'SSL_CERT_FILE', 'CURL_CA_BUNDLE',
+                    'PIP_CERT', 'POETRY_CERTIFICATES_PYPI_CERT', 'BUNDLE_SSL_CA_CERT'):
+            monkeypatch.delenv(var, raising=False)
+
+        primary = tmp_path / 'primary.pem'
+        primary.write_text(mock_data.MOCK_CERTIFICATE)
+        aikido = tmp_path / 'aikido.pem'
+        aikido.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+        shell_config = home / '.zshrc'
+
+        inst = _aikido_instance_with_root(aikido)
+        inst.mode = 'install'
+        inst.cert_path = str(primary)
+
+        with patch.object(inst, 'command_exists', side_effect=lambda c: c == 'python3'), \
+             patch.object(inst, 'detect_shell', return_value='zsh'), \
+             patch.object(inst, 'get_shell_config', return_value=str(shell_config)), \
+             patch.object(inst, 'create_bundle_with_system_certs',
+                          side_effect=_seed_system_certs):
+            result = inst.setup_python_cert()
+
+        python_bundle = str(home / '.python-ca-bundle.pem')
+        content = shell_config.read_text()
+        for var in ('SSL_CERT_FILE', 'REQUESTS_CA_BUNDLE', 'CURL_CA_BUNDLE',
+                    'PIP_CERT', 'POETRY_CERTIFICATES_PYPI_CERT', 'BUNDLE_SSL_CA_CERT'):
+            assert f'export {var}="{python_bundle}"' in content
+        # All six live in a single managed block.
+        assert content.count(inst._FUMITM_BLOCK_BEGIN) == 1
+        assert result.status == 'configured'
+
+    def test_suspicious_requests_bundle_still_reclaims_vendor_vars(
+            self, tmp_path, monkeypatch):
+        # A writable but suspicious REQUESTS_CA_BUNDLE used to return early after
+        # repointing only the three core vars, leaving PIP_CERT/Poetry/Bundler at
+        # the vendor bundle. The suspicious path must now fall through to the
+        # trust-var post-pass so every Python var lands on the both-roots bundle.
+        home = tmp_path / 'home'
+        home.mkdir()
+        monkeypatch.setenv('HOME', str(home))
+
+        suspicious = tmp_path / 'vendor-only.pem'
+        suspicious.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)  # single cert -> suspicious
+        monkeypatch.setenv('REQUESTS_CA_BUNDLE', str(suspicious))
+        monkeypatch.setenv('PIP_CERT', str(suspicious))
+        for var in ('SSL_CERT_FILE', 'CURL_CA_BUNDLE',
+                    'POETRY_CERTIFICATES_PYPI_CERT', 'BUNDLE_SSL_CA_CERT'):
+            monkeypatch.delenv(var, raising=False)
+
+        primary = tmp_path / 'primary.pem'
+        primary.write_text(mock_data.MOCK_CERTIFICATE)
+        aikido = tmp_path / 'aikido.pem'
+        aikido.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+        shell_config = home / '.zshrc'
+
+        inst = _aikido_instance_with_root(aikido)
+        inst.mode = 'install'
+        inst.cert_path = str(primary)
+
+        with patch.object(inst, 'command_exists', side_effect=lambda c: c == 'python3'), \
+             patch.object(inst, 'detect_shell', return_value='zsh'), \
+             patch.object(inst, 'get_shell_config', return_value=str(shell_config)), \
+             patch.object(inst, 'create_bundle_with_system_certs',
+                          side_effect=_seed_system_certs):
+            result = inst.setup_python_cert()
+
+        python_bundle = str(home / '.python-ca-bundle.pem')
+        content = shell_config.read_text()
+        for var in ('SSL_CERT_FILE', 'REQUESTS_CA_BUNDLE', 'CURL_CA_BUNDLE',
+                    'PIP_CERT', 'POETRY_CERTIFICATES_PYPI_CERT', 'BUNDLE_SSL_CA_CERT'):
+            assert f'export {var}="{python_bundle}"' in content
+        # The vendor bundle is no longer referenced by any managed export.
+        assert str(suspicious) not in content
+        assert result.status == 'configured'
+
+
+class TestAikidoGcloudReauthTrust(FumitmTestCase):
+    """With Aikido active, setup_gcloud_cert reclaims the reauth trust vars.
+
+    gcloud's reauth handshake runs through the bundled requests library, which
+    honors REQUESTS_CA_BUNDLE then CURL_CA_BUNDLE rather than
+    core/custom_ca_certs_file. Aikido exports both at its own bundle, which lacks
+    the primary proxy root, so reauth fails with "self-signed certificate in
+    certificate chain" even when the gcloud property is correct. The gcloud setup
+    must therefore re-assert both vars at the both-roots bundle.
+    """
+
+    def test_reauth_vars_reclaimed_when_aikido_active(self, tmp_path, monkeypatch):
+        home = tmp_path / 'home'
+        home.mkdir()
+        monkeypatch.setenv('HOME', str(home))
+        python_bundle = home / '.python-ca-bundle.pem'
+        python_bundle.write_text(mock_data.MOCK_CERTIFICATE)
+        aikido = tmp_path / 'aikido.pem'
+        aikido.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+        shell_config = home / '.zshrc'
+
+        inst = _aikido_instance_with_root(aikido)
+        inst.mode = 'install'
+
+        # gcloud already points at the both-roots bundle, so the property path is
+        # a no-op; the reauth env vars are the only thing left to fix.
+        get_value = MagicMock(returncode=0, stdout=str(python_bundle))
+        with patch.object(inst, 'command_exists', return_value=True), \
+             patch.object(inst, '_ensure_gcloud_properties', return_value=False), \
+             patch.object(inst, 'detect_shell', return_value='zsh'), \
+             patch.object(inst, 'get_shell_config', return_value=str(shell_config)), \
+             patch.object(inst, 'is_suspicious_full_bundle', return_value=(False, None)), \
+             patch.object(inst, '_all_roots_present_in_file', return_value=True), \
+             patch('fumitm.subprocess.run', return_value=get_value):
+            result = inst.setup_gcloud_cert()
+
+        content = shell_config.read_text()
+        for var in ('REQUESTS_CA_BUNDLE', 'CURL_CA_BUNDLE'):
+            assert f'export {var}="{python_bundle}"' in content
+        # The reclaimed vars live in the always-last managed block so they win
+        # over Aikido's earlier vendor export by last-export-wins.
+        assert content.count(inst._FUMITM_BLOCK_BEGIN) == 1
+        # A reauth-only change must be reported, not masked as already_ok.
+        assert result.status == 'configured'
+
+    def test_reauth_vars_untouched_without_supplemental_root(
+            self, tmp_path, monkeypatch):
+        home = tmp_path / 'home'
+        home.mkdir()
+        monkeypatch.setenv('HOME', str(home))
+        python_bundle = home / '.python-ca-bundle.pem'
+        python_bundle.write_text(mock_data.MOCK_CERTIFICATE)
+        shell_config = home / '.zshrc'
+
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True)
+        inst.mode = 'install'
+
+        get_value = MagicMock(returncode=0, stdout=str(python_bundle))
+        with patch.object(inst, 'command_exists', return_value=True), \
+             patch.object(inst, '_ensure_gcloud_properties', return_value=False), \
+             patch.object(inst, 'detect_shell', return_value='zsh'), \
+             patch.object(inst, 'get_shell_config', return_value=str(shell_config)), \
+             patch.object(inst, 'is_suspicious_full_bundle', return_value=(False, None)), \
+             patch.object(inst, '_all_roots_present_in_file', return_value=True), \
+             patch('fumitm.subprocess.run', return_value=get_value):
+            inst.setup_gcloud_cert()
+
+        content = shell_config.read_text()
+        # Plain single-provider hosts keep only the gcloud property var; the
+        # Python/curl trust vars are left to setup_python_cert.
+        assert 'CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE' in content
+        assert 'REQUESTS_CA_BUNDLE' not in content
+        assert 'CURL_CA_BUNDLE' not in content
+
+
+class TestAikidoWget(FumitmTestCase):
+    """wget gets a both-roots bundle; the status check reads the last directive."""
+
+    def test_setup_wget_writes_both_roots_bundle(self, tmp_path, monkeypatch):
+        home = tmp_path / 'home'
+        home.mkdir()
+        monkeypatch.setenv('HOME', str(home))
+        primary = tmp_path / 'primary.pem'
+        primary.write_text(mock_data.MOCK_CERTIFICATE)
+        aikido = tmp_path / 'aikido.pem'
+        aikido.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+
+        inst = _aikido_instance_with_root(aikido)
+        inst.mode = 'install'
+        inst.cert_path = str(primary)
+        inst.bundle_dir = str(home / '.netskope')
+
+        with patch.object(inst, 'command_exists', side_effect=lambda c: c == 'wget'), \
+             patch.object(inst, 'verify_connection', return_value='FAILED'), \
+             patch.object(inst, 'create_bundle_with_system_certs',
+                          side_effect=_seed_system_certs):
+            result = inst.setup_wget_cert()
+
+        wget_bundle = home / '.netskope' / 'wget' / 'ca-bundle.pem'
+        wgetrc = home / '.wgetrc'
+        assert result.status == 'configured'
+        assert wget_bundle.exists()
+        body = wget_bundle.read_text()
+        assert mock_data.MOCK_CERTIFICATE.strip() in body
+        assert mock_data.MOCK_AIKIDO_ROOT_CERT.strip() in body
+        assert f'ca_certificate={wget_bundle}' in wgetrc.read_text()
+
+    def test_last_active_wgetrc_ca_picks_last_uncommented(self):
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True)
+        content = (
+            '#ca_certificate=/commented.pem\n'
+            'ca_certificate=/first.pem\n'
+            'ca_certificate=/second.pem\n'
+        )
+        assert inst._last_active_wgetrc_ca(content) == '/second.pem'
+        assert inst._last_active_wgetrc_ca('# nothing here\n') is None
+
+
+class TestAikidoCertFileExpansion(FumitmTestCase):
+    """--aikido-cert is stored raw and expanded at read time, after user targeting
+    may have rewritten HOME (sudo / --run-as-user)."""
+
+    def test_stored_raw_not_expanded_at_construction(self):
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True,
+                                           aikido_cert_file='~/aikido-root.pem')
+        assert inst.aikido_cert_file == '~/aikido-root.pem'
+
+    def test_expanded_against_current_home_at_read_time(self, tmp_path, monkeypatch):
+        monkeypatch.setenv('HOME', str(tmp_path))
+        cert = tmp_path / 'aikido-root.pem'
+        cert.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True,
+                                           aikido_cert_file='~/aikido-root.pem')
+        # Linux skips the keychain; the tilde must resolve under the (mocked) HOME.
+        with patch('fumitm.platform.system', return_value='Linux'), \
+             patch.object(inst, '_openssl_subject', side_effect=_fake_subject):
+            result = inst._get_aikido_root_cert()
+        assert result is not None
+        assert 'AIKIDOROOT' in result
+
+
+class TestMultiRootMatching(FumitmTestCase):
+    """A multi-certificate source is reported present only when every cert is in
+    the bundle (e.g. several Aikido roots returned during a rotation)."""
+
+    def test_every_block_must_be_present(self, tmp_path):
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True)
+        two_roots = tmp_path / 'two_roots.pem'
+        two_roots.write_text(
+            mock_data.MOCK_AIKIDO_ROOT_CERT + '\n'
+            + mock_data.MOCK_AIKIDO_INTERMEDIATE_CERT
+        )
+
+        # Bundle holds only the first root -> the second is missing.
+        first_only = tmp_path / 'first_only.pem'
+        first_only.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+        assert inst.certificate_likely_exists_in_file(
+            str(two_roots), str(first_only)) is False
+        assert inst.certificate_exists_in_file(
+            str(two_roots), str(first_only)) is False
+
+        # Bundle holds both -> complete.
+        both = tmp_path / 'both.pem'
+        both.write_text(
+            mock_data.MOCK_AIKIDO_ROOT_CERT + '\n'
+            + mock_data.MOCK_AIKIDO_INTERMEDIATE_CERT
+        )
+        assert inst.certificate_likely_exists_in_file(
+            str(two_roots), str(both)) is True
+
+    def test_single_cert_behaviour_unchanged(self, tmp_path):
+        inst = self.create_fumitm_instance(provider='warp', no_aikido=True)
+        single = tmp_path / 'single.pem'
+        single.write_text(mock_data.MOCK_CERTIFICATE)
+        bundle = tmp_path / 'bundle.pem'
+        bundle.write_text('PREFIX\n' + mock_data.MOCK_CERTIFICATE + '\nSUFFIX\n')
+        assert inst.certificate_likely_exists_in_file(str(single), str(bundle)) is True
+        empty = tmp_path / 'empty.pem'
+        empty.write_text('')
+        assert inst.certificate_likely_exists_in_file(str(single), str(empty)) is False

--- a/test_suite/test_fumitm_integration.py
+++ b/test_suite/test_fumitm_integration.py
@@ -1261,14 +1261,17 @@ class TestBundleCreation(FumitmTestCase):
         with patch('platform.system', return_value='Darwin'):
             instance = fumitm.FumitmPython(mode='install')
 
-            # Mock os.path.exists: neither system cert location exists
+            # Mock os.path.exists: neither system cert location exists.
+            # The assertions run outside this patch because Python 3.13's
+            # pathlib.Path.exists() delegates to os.path.exists(), so a global
+            # patch would otherwise mask the file the method actually created.
             with patch('os.path.exists', return_value=False):
                 result = instance.create_bundle_with_system_certs(str(target_bundle))
 
-                # Should create empty file and return False
-                assert result is False
-                assert target_bundle.exists()
-                assert target_bundle.read_text() == ""
+            # Should create empty file and return False
+            assert result is False
+            assert target_bundle.exists()
+            assert target_bundle.read_text() == ""
 
     def test_returns_true_when_system_certs_copied(self, tmp_path):
         """Test return value indicates whether system certs were found."""

--- a/test_suite/test_fumitm_integration.py
+++ b/test_suite/test_fumitm_integration.py
@@ -806,7 +806,7 @@ class TestCLIAndWorkflow(FumitmTestCase):
     _DEFAULT_NEW_KWARGS = dict(
         no_color=False, headless=False, skip_update_check=False,
         log_file=None, log_dir=None, json_log_file=None, json_log_dir=None,
-        run_as_user=None,
+        run_as_user=None, with_aikido=False, no_aikido=False,
     )
 
     @patch('fumitm.sys.argv', ['fumitm.py', '--fix'])

--- a/test_suite/test_fumitm_integration.py
+++ b/test_suite/test_fumitm_integration.py
@@ -807,6 +807,7 @@ class TestCLIAndWorkflow(FumitmTestCase):
         no_color=False, headless=False, skip_update_check=False,
         log_file=None, log_dir=None, json_log_file=None, json_log_dir=None,
         run_as_user=None, with_aikido=False, no_aikido=False,
+        aikido_cert_file=None,
     )
 
     @patch('fumitm.sys.argv', ['fumitm.py', '--fix'])
@@ -3333,7 +3334,9 @@ class TestBareReturnsFixed(FumitmTestCase):
              patch.object(instance, 'add_to_shell_config') as mock_shell:
             result = instance.setup_python_cert()
             assert result.status == 'configured'
-            mock_shell.assert_called_with('SSL_CERT_FILE', bundle_path, '/tmp/.zshrc')
+            # assert_any_call (not assert_called_with): the Aikido/vendor-var
+            # post-pass may append further trust-var calls after this one.
+            mock_shell.assert_any_call('SSL_CERT_FILE', bundle_path, '/tmp/.zshrc')
 
     def test_gcloud_pre_bootstrap_without_gcloud_returns_configured(self):
         """setup_gcloud_cert returns configured when pre-bootstrap changes config."""
@@ -3376,7 +3379,7 @@ class TestBareReturnsFixed(FumitmTestCase):
              patch.object(instance, 'detect_shell', return_value='zsh'), \
              patch.object(instance, 'get_shell_config', return_value=shell_config), \
              patch('builtins.open', mock_open_obj), \
-             patch.object(instance, 'add_to_shell_config'):
+             patch.object(instance, 'add_to_shell_config', return_value=False):
             result = instance.setup_gcloud_cert()
             assert result.status == 'skipped'
             assert result.tool == 'gcloud'
@@ -3969,58 +3972,63 @@ class TestGitTlsBackend(FumitmTestCase):
 
 
 class TestShellConfigIdempotency(FumitmTestCase):
-    """Ensure add_to_shell_config is a no-op when the active export already
-    matches the desired value.
+    """add_to_shell_config maintains a trailing managed block and is a no-op only
+    when that block is already present and correct at the end of the file.
 
-    Regression: previously the function only checked whether `export VAR=`
-    appeared anywhere in the file and prompted the user even when the
-    existing value was correct. Saying "y" rewrote the file with an
-    identical line, falsely flagged shell_modified, and produced a
-    "1 configured" entry plus a "source ~/.zshrc" hint on every run.
+    The managed block wins by last-export-wins, so a user's earlier export is
+    preserved verbatim but overridden — never commented out, never prompted.
     """
 
-    def test_idempotent_when_value_matches(self, tmp_path):
+    def test_idempotent_when_block_already_correct(self, tmp_path):
         instance = self.create_fumitm_instance(mode='install')
         rc = tmp_path / '.zshrc'
         original = (
             '# user prologue\n'
             'export PATH="/usr/local/bin:$PATH"\n'
+            '\n'
+            f'{instance._FUMITM_BLOCK_BEGIN}\n'
             'export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="/Users/test/.python-ca-bundle.pem"\n'
-            '# user epilogue\n'
+            f'{instance._FUMITM_BLOCK_END}\n'
         )
         rc.write_text(original)
 
-        with patch.object(instance, '_prompt') as prompt:
-            instance.add_to_shell_config(
-                'CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE',
-                '/Users/test/.python-ca-bundle.pem',
-                str(rc),
-            )
+        changed = instance.add_to_shell_config(
+            'CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE',
+            '/Users/test/.python-ca-bundle.pem',
+            str(rc),
+        )
 
-        assert prompt.call_count == 0, "should not prompt when value already matches"
+        assert changed is False
         assert rc.read_text() == original, "file should be untouched"
         assert getattr(instance, 'shell_modified', False) is False
+        assert not (tmp_path / '.zshrc.bak').exists()
 
-    def test_prompts_and_rewrites_when_value_differs(self, tmp_path):
+    def test_overrides_differing_value_without_prompt(self, tmp_path):
         instance = self.create_fumitm_instance(mode='install')
         rc = tmp_path / '.zshrc'
         rc.write_text(
             'export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="/old/path.pem"\n'
         )
 
-        with patch.object(instance, '_prompt', return_value='y'):
-            instance.add_to_shell_config(
+        with patch.object(instance, '_prompt') as prompt:
+            changed = instance.add_to_shell_config(
                 'CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE',
                 '/new/path.pem',
                 str(rc),
             )
 
         new_content = rc.read_text()
-        assert '#export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="/old/path.pem"' in new_content
-        assert 'export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="/new/path.pem"' in new_content
+        assert prompt.call_count == 0, "managed block is authoritative; no prompt"
+        # The user's earlier line is preserved (never commented), and the managed
+        # block at EOF carries the new value, winning by last-export-wins.
+        assert 'export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="/old/path.pem"' in new_content
+        assert '#export' not in new_content
+        assert new_content.rstrip().endswith(instance._FUMITM_BLOCK_END)
+        assert new_content.index('/new/path.pem') > new_content.index('/old/path.pem')
+        assert changed is True
         assert instance.shell_modified is True
 
-    def test_appends_when_only_commented_export_exists(self, tmp_path):
+    def test_value_lands_inside_managed_block(self, tmp_path):
         instance = self.create_fumitm_instance(mode='install')
         rc = tmp_path / '.zshrc'
         rc.write_text('#export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="/old/path.pem"\n')
@@ -4032,25 +4040,178 @@ class TestShellConfigIdempotency(FumitmTestCase):
                 str(rc),
             )
 
+        content = rc.read_text()
         assert prompt.call_count == 0, "commented-out lines should not trigger a prompt"
-        assert 'export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="/new/path.pem"' in rc.read_text()
+        begin = content.index(instance._FUMITM_BLOCK_BEGIN)
+        export = content.index('export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="/new/path.pem"')
+        end = content.index(instance._FUMITM_BLOCK_END)
+        assert begin < export < end
         assert instance.shell_modified is True
 
-    def test_idempotent_with_unquoted_existing_value(self, tmp_path):
+    def test_plain_user_export_preserved_and_overridden(self, tmp_path):
+        # A pre-existing unquoted user export is foreign content: preserved
+        # verbatim, with a managed block appended that overrides it.
         instance = self.create_fumitm_instance(mode='install')
         rc = tmp_path / '.zshrc'
         original = 'export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE=/Users/test/bundle.pem\n'
         rc.write_text(original)
 
-        with patch.object(instance, '_prompt') as prompt:
-            instance.add_to_shell_config(
-                'CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE',
-                '/Users/test/bundle.pem',
-                str(rc),
-            )
+        changed = instance.add_to_shell_config(
+            'CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE',
+            '/Users/test/bundle.pem',
+            str(rc),
+        )
 
-        assert prompt.call_count == 0
-        assert rc.read_text() == original
+        content = rc.read_text()
+        assert changed is True
+        assert original.strip() in content, "user line preserved"
+        assert instance._FUMITM_BLOCK_BEGIN in content
+        assert content.rstrip().endswith(instance._FUMITM_BLOCK_END)
+
+
+class TestShellConfigManagedBlock(FumitmTestCase):
+    """The managed block is always re-emitted last, after any vendor (Aikido)
+    block, and relocates itself there on every run.
+    """
+
+    def _aikido_block(self):
+        return (
+            '# >>> aikido-endpoint start >>>\n'
+            'export SSL_CERT_FILE="/aikido/only.pem"\n'
+            'export REQUESTS_CA_BUNDLE="/aikido/only.pem"\n'
+            '# <<< aikido-endpoint end <<<\n'
+        )
+
+    def test_order_wins_over_aikido(self, tmp_path):
+        instance = self.create_fumitm_instance(mode='install')
+        rc = tmp_path / '.zshrc'
+        aikido = self._aikido_block()
+        # An earlier fumitm export followed by Aikido's block, which currently wins.
+        rc.write_text(
+            'export SSL_CERT_FILE="/fumitm/bundle.pem"\n\n' + aikido
+        )
+
+        instance.add_to_shell_config('SSL_CERT_FILE', '/fumitm/bundle.pem', str(rc))
+        instance.add_to_shell_config('REQUESTS_CA_BUNDLE', '/fumitm/bundle.pem', str(rc))
+
+        content = rc.read_text()
+        # Aikido's block is preserved verbatim, and the fumitm block sits after it.
+        assert aikido.strip() in content
+        assert content.index(instance._FUMITM_BLOCK_BEGIN) > content.index('aikido-endpoint end')
+        # The managed-block copy (last occurrence) wins over Aikido's earlier line.
+        assert content.rindex('export SSL_CERT_FILE="/fumitm/bundle.pem"') \
+            > content.index('export SSL_CERT_FILE="/aikido/only.pem"')
+        assert 'export REQUESTS_CA_BUNDLE="/fumitm/bundle.pem"' in content
+
+        # Second pass is byte-identical (idempotent).
+        before = rc.read_text()
+        changed = instance.add_to_shell_config('SSL_CERT_FILE', '/fumitm/bundle.pem', str(rc))
+        assert changed is False
+        assert rc.read_text() == before
+
+    def test_relocates_block_to_eof_when_mid_file(self, tmp_path):
+        instance = self.create_fumitm_instance(mode='install')
+        rc = tmp_path / '.zshrc'
+        rc.write_text(
+            f'{instance._FUMITM_BLOCK_BEGIN}\n'
+            'export SSL_CERT_FILE="/fumitm/bundle.pem"\n'
+            f'{instance._FUMITM_BLOCK_END}\n'
+            '\n'
+            'export LATER_USER_VAR="kept"\n'
+        )
+
+        changed = instance.add_to_shell_config('REQUESTS_CA_BUNDLE', '/fumitm/bundle.pem', str(rc))
+
+        content = rc.read_text()
+        assert changed is True
+        assert 'export LATER_USER_VAR="kept"' in content
+        assert content.index('LATER_USER_VAR') < content.index(instance._FUMITM_BLOCK_BEGIN)
+        assert content.rstrip().endswith(instance._FUMITM_BLOCK_END)
+
+    def test_multiple_vars_accumulate_in_one_block(self, tmp_path):
+        instance = self.create_fumitm_instance(mode='install')
+        rc = tmp_path / '.zshrc'
+        instance.add_to_shell_config('SSL_CERT_FILE', '/b.pem', str(rc))
+        instance.add_to_shell_config('REQUESTS_CA_BUNDLE', '/b.pem', str(rc))
+
+        content = rc.read_text()
+        assert content.count(instance._FUMITM_BLOCK_BEGIN) == 1
+        assert content.count(instance._FUMITM_BLOCK_END) == 1
+        assert 'export SSL_CERT_FILE="/b.pem"' in content
+        assert 'export REQUESTS_CA_BUNDLE="/b.pem"' in content
+
+    def test_per_run_backup_holds_pre_run_original(self, tmp_path):
+        instance = self.create_fumitm_instance(mode='install')
+        rc = tmp_path / '.zshrc'
+        original = 'export USER_VAR="original"\n'
+        rc.write_text(original)
+
+        instance.add_to_shell_config('SSL_CERT_FILE', '/b.pem', str(rc))
+        instance.add_to_shell_config('REQUESTS_CA_BUNDLE', '/b.pem', str(rc))
+
+        bak = tmp_path / '.zshrc.bak'
+        assert bak.exists()
+        assert bak.read_text() == original, "bak must hold the true pre-run original"
+
+    def test_missing_file_creates_block_no_bak(self, tmp_path):
+        instance = self.create_fumitm_instance(mode='install')
+        rc = tmp_path / '.zshrc'  # does not exist
+
+        changed = instance.add_to_shell_config('SSL_CERT_FILE', '/b.pem', str(rc))
+
+        assert changed is True
+        content = rc.read_text()
+        assert content.startswith(instance._FUMITM_BLOCK_BEGIN)
+        assert content.endswith(instance._FUMITM_BLOCK_END + '\n')
+        assert not (tmp_path / '.zshrc.bak').exists()
+        # A second var in the same run must not back up the intermediate file.
+        instance.add_to_shell_config('REQUESTS_CA_BUNDLE', '/b.pem', str(rc))
+        assert not (tmp_path / '.zshrc.bak').exists()
+
+    def test_returns_false_on_noop(self, tmp_path):
+        instance = self.create_fumitm_instance(mode='install')
+        rc = tmp_path / '.zshrc'
+        assert instance.add_to_shell_config('SSL_CERT_FILE', '/b.pem', str(rc)) is True
+        assert instance.add_to_shell_config('SSL_CERT_FILE', '/b.pem', str(rc)) is False
+
+    def test_stray_begin_marker_preserves_content(self, tmp_path):
+        instance = self.create_fumitm_instance(mode='install')
+        rc = tmp_path / '.zshrc'
+        rc.write_text(
+            f'{instance._FUMITM_BLOCK_BEGIN}\n'
+            'export USER_IMPORTANT="keepme"\n'  # no end marker
+        )
+
+        with patch.object(instance, 'print_warn') as warn:
+            changed = instance.add_to_shell_config('SSL_CERT_FILE', '/b.pem', str(rc))
+
+        content = rc.read_text()
+        assert changed is True
+        assert 'export USER_IMPORTANT="keepme"' in content, "no content swallowed to EOF"
+        assert warn.call_count >= 1
+        assert content.rstrip().endswith(instance._FUMITM_BLOCK_END)
+
+    def test_stale_begin_then_fresh_block(self, tmp_path):
+        # A stale unmatched begin marker followed by a valid fresh block: the
+        # fresh block's end must not be read as closing the stale begin.
+        instance = self.create_fumitm_instance(mode='install')
+        rc = tmp_path / '.zshrc'
+        rc.write_text(
+            f'{instance._FUMITM_BLOCK_BEGIN}\n'
+            'export STALE_LEFTOVER="x"\n'
+            '\n'
+            f'{instance._FUMITM_BLOCK_BEGIN}\n'
+            'export SSL_CERT_FILE="/old.pem"\n'
+            f'{instance._FUMITM_BLOCK_END}\n'
+        )
+
+        instance.add_to_shell_config('SSL_CERT_FILE', '/new.pem', str(rc))
+
+        content = rc.read_text()
+        # The fresh block was updated; the stale begin + its line stay as foreign.
+        assert 'export STALE_LEFTOVER="x"' in content
+        assert 'export SSL_CERT_FILE="/new.pem"' in content
+        assert 'export SSL_CERT_FILE="/old.pem"' not in content
 
 
 if __name__ == '__main__':

--- a/test_suite/test_headless_mdm.py
+++ b/test_suite/test_headless_mdm.py
@@ -121,20 +121,30 @@ class TestNonInteractiveError(FumitmTestCase):
             assert result == 'y'
 
     def test_main_catches_non_interactive_error(self):
-        """NonInteractiveError in main() returns exit code 2."""
+        """NonInteractiveError raised during a setup makes main() return exit code 2."""
         instance = self.create_fumitm_instance(mode='install')
+
+        # Replace the registry with a single tool whose setup deterministically
+        # needs interactive input, so the test does not depend on the host's
+        # real tools happening to prompt. The real _prompt raises
+        # NonInteractiveError because stdin is not a TTY and --yes is off.
+        def prompting_setup():
+            instance._prompt("Continue? (y/N) ")
+
+        instance.tools_registry = {
+            'fake': {
+                'name': 'Fake Tool', 'tags': [], 'scope': 'system',
+                'setup_func': prompting_setup, 'check_func': None,
+            }
+        }
+
         with patch.object(instance, 'check_for_updates'), \
              patch.object(instance, 'is_devcontainer', return_value=False), \
              patch.object(instance, 'check_environment_sanity'), \
              patch.object(instance, 'check_ownership_sanity'), \
              patch.object(instance, 'download_certificate', return_value=True), \
-             patch.object(
-                 instance, '_prompt',
-                 side_effect=NonInteractiveError("stdin not a TTY")
-             ), \
              patch('sys.stdin') as mock_stdin:
             mock_stdin.isatty.return_value = False
-            # Force a code path that calls _prompt
             exit_code = instance.main()
             assert exit_code == 2
 

--- a/test_suite/test_netskope_provider.py
+++ b/test_suite/test_netskope_provider.py
@@ -283,6 +283,7 @@ class TestProviderCLI(FumitmTestCase):
         no_color=False, headless=False, skip_update_check=False,
         log_file=None, log_dir=None, json_log_file=None, json_log_dir=None,
         run_as_user=None, with_aikido=False, no_aikido=False,
+        aikido_cert_file=None,
     )
 
     @patch('fumitm.sys.argv', ['fumitm.py', '--provider', 'netskope'])

--- a/test_suite/test_netskope_provider.py
+++ b/test_suite/test_netskope_provider.py
@@ -282,7 +282,7 @@ class TestProviderCLI(FumitmTestCase):
     _DEFAULT_NEW_KWARGS = dict(
         no_color=False, headless=False, skip_update_check=False,
         log_file=None, log_dir=None, json_log_file=None, json_log_dir=None,
-        run_as_user=None,
+        run_as_user=None, with_aikido=False, no_aikido=False,
     )
 
     @patch('fumitm.sys.argv', ['fumitm.py', '--provider', 'netskope'])


### PR DESCRIPTION
Support Aikido interception across the whole toolchain. Should close #88.

Aikido does selective TLS interception on top of the primary provider (WARP/Netskope), so a fumitm bundle carrying only the primary root blows up on Aikido-grabbed hosts -- `invalid peer certificate: UnknownIssuer` under rustls (`uv`), `certificate verify failed` under OpenSSL, etc. It's modeled as a supplemental root added alongside the primary, never a selectable provider.

When Aikido's present fumitm auto-adds its root to every bundle, keystore, and container VM, with an override of `--with-aikido`/`--no-aikido`. For CI or no-agent images `--aikido-cert PATH` supplies the root, or a `~/.aikido-ca.pem` persisted from an earlier run gets reused.

The annoying part was making the trust actually stick. fumitm now keeps its exports in a marker-delimited block re-emitted last, so it wins over a vendor's earlier block by last-export-wins, and reclaims the vars a vendor injects at its own single-root bundle (`PIP_CERT`/Poetry/Bundler for Python, `REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE` for gcloud's reauth handshake, which ignores `core/custom_ca_certs_file`). Presence checks went multi-cert aware -- `brew postinstall` rebuilds from the keychain and drops combined-PEM-only certs, so the missing ones get appended and it should only fail when the keychain's missing the primary root entirely.

macOS/Linux only; the Windows port doesn't add the Aikido root yet.

New `test_aikido_root.py` covers the explicit/persisted sources, container split-file status, brew append, the Python/gcloud/wget var reclamation, and multi-root matching -- full suite's 376 passing.
