### PR TITLE
chore: make ruff check clean across the repo

### DIFF
--- a/fumitm.py
+++ b/fumitm.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
 
-import os
-import re
-import sys
-import subprocess
-import tempfile
-import shutil
 import argparse
-import platform
 import json
-import ssl
+import os
+import platform
 import pwd
-import urllib.request
+import re
+import shutil
+import ssl
+import subprocess
+import sys
+import tempfile
 import urllib.error
+import urllib.request
 from collections import namedtuple
 from datetime import datetime, timezone
 from pathlib import Path
@@ -59,7 +59,7 @@ def get_version_info():
             ['git', 'rev-parse', '--git-dir'],
             cwd=script_dir,
             capture_output=True,
-            text=True
+            text=True, check=False
         )
         
         if result.returncode == 0:
@@ -68,7 +68,7 @@ def get_version_info():
                 ['git', 'rev-parse', '--short', 'HEAD'],
                 cwd=script_dir,
                 capture_output=True,
-                text=True
+                text=True, check=False
             )
             if result.returncode == 0:
                 version_info['commit'] = result.stdout.strip()
@@ -78,7 +78,7 @@ def get_version_info():
                 ['git', 'log', '-1', '--format=%cd', '--date=short'],
                 cwd=script_dir,
                 capture_output=True,
-                text=True
+                text=True, check=False
             )
             if result.returncode == 0:
                 version_info['date'] = result.stdout.strip()
@@ -88,7 +88,7 @@ def get_version_info():
                 ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
                 cwd=script_dir,
                 capture_output=True,
-                text=True
+                text=True, check=False
             )
             if result.returncode == 0:
                 version_info['branch'] = result.stdout.strip()
@@ -98,7 +98,7 @@ def get_version_info():
                 ['git', 'status', '--porcelain'],
                 cwd=script_dir,
                 capture_output=True,
-                text=True
+                text=True, check=False
             )
             if result.returncode == 0 and result.stdout.strip():
                 version_info['dirty'] = True
@@ -109,7 +109,7 @@ def get_version_info():
                 cwd=script_dir,
                 capture_output=True,
                 text=True,
-                stderr=subprocess.DEVNULL
+                stderr=subprocess.DEVNULL, check=False
             )
             if result.returncode == 0 and result.stdout.strip():
                 version_info['version'] = result.stdout.strip()
@@ -119,7 +119,7 @@ def get_version_info():
                     ['git', 'rev-list', '--count', 'HEAD'],
                     cwd=script_dir,
                     capture_output=True,
-                    text=True
+                    text=True, check=False
                 )
                 if result.returncode == 0 and result.stdout.strip():
                     count = result.stdout.strip()
@@ -543,7 +543,7 @@ class FumitmPython:
             proc_pattern = 'Netskope Client' if plat == 'Darwin' else 'STAgent'
             result = subprocess.run(
                 ['pgrep', '-f', proc_pattern],
-                capture_output=True, text=True
+                capture_output=True, text=True, check=False
             )
             if result.returncode == 0 and result.stdout.strip():
                 return True
@@ -592,7 +592,7 @@ class FumitmPython:
                     ['security', 'find-certificate', '-c',
                      descriptor['keychain_label_prefix'],
                      '/Library/Keychains/System.keychain'],
-                    capture_output=True, text=True
+                    capture_output=True, text=True, check=False
                 )
                 if result.returncode == 0:
                     return True
@@ -635,7 +635,7 @@ class FumitmPython:
                 result = subprocess.run(
                     ['security', 'find-certificate', '-a', '-c', prefix, '-p',
                      '/Library/Keychains/System.keychain'],
-                    capture_output=True, text=True
+                    capture_output=True, text=True, check=False
                 )
                 if result.returncode == 0 and '-----BEGIN CERTIFICATE-----' in result.stdout:
                     roots = self._filter_certs_by_cn_prefix(result.stdout, prefix)
@@ -716,7 +716,7 @@ class FumitmPython:
         try:
             result = subprocess.run(
                 ['openssl', 'x509', '-noout', '-subject', '-in', tmp_path],
-                capture_output=True, text=True
+                capture_output=True, text=True, check=False
             )
             if result.returncode != 0:
                 return None
@@ -786,7 +786,7 @@ class FumitmPython:
             return list(self.tools_registry.keys())
         
         selected = []
-        for tool_key, tool_info in self.tools_registry.items():
+        for tool_key in self.tools_registry:
             if self.should_process_tool(tool_key):
                 selected.append(tool_key)
         
@@ -832,14 +832,14 @@ class FumitmPython:
         Directory mode (--log-dir / --json-log-dir): generates timestamped
         filenames and maintains a 'fumitm-latest' symlink to the most recent.
         """
-        ts = datetime.now().strftime('%Y%m%d-%H%M%S')
+        ts = datetime.now(timezone.utc).astimezone().strftime('%Y%m%d-%H%M%S')
         pid = os.getpid()
 
         if self._log_dir:
             try:
                 os.makedirs(self._log_dir, exist_ok=True)
                 path = os.path.join(self._log_dir, f"fumitm-{ts}-{pid}.log")
-                self._log_file_handle = open(path, 'w')
+                self._log_file_handle = open(path, 'w')  # noqa: SIM115 (closed in _close_log_files)
                 symlink = os.path.join(self._log_dir, 'fumitm-latest.log')
                 self._update_symlink(symlink, path)
             except OSError as e:
@@ -852,7 +852,7 @@ class FumitmPython:
                 parent = os.path.dirname(self._log_file_path)
                 if parent:
                     os.makedirs(parent, exist_ok=True)
-                self._log_file_handle = open(self._log_file_path, 'w')
+                self._log_file_handle = open(self._log_file_path, 'w')  # noqa: SIM115 (closed in _close_log_files)
             except OSError as e:
                 print(
                     f"[WARN] Cannot open log file {self._log_file_path}: {e}",
@@ -865,7 +865,7 @@ class FumitmPython:
                 path = os.path.join(
                     self._json_log_dir, f"fumitm-{ts}-{pid}.jsonl",
                 )
-                self._json_log_file_handle = open(path, 'w')
+                self._json_log_file_handle = open(path, 'w')  # noqa: SIM115 (closed in _close_log_files)
                 symlink = os.path.join(
                     self._json_log_dir, 'fumitm-latest.jsonl',
                 )
@@ -881,7 +881,7 @@ class FumitmPython:
                 parent = os.path.dirname(self._json_log_file_path)
                 if parent:
                     os.makedirs(parent, exist_ok=True)
-                self._json_log_file_handle = open(
+                self._json_log_file_handle = open(  # noqa: SIM115 (closed in _close_log_files)
                     self._json_log_file_path, 'w',
                 )
             except OSError as e:
@@ -943,7 +943,7 @@ class FumitmPython:
 
         # Text log: always strip ANSI, add timestamp
         if self._log_file_handle:
-            ts = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
+            ts = datetime.now(timezone.utc).astimezone().strftime('%Y-%m-%dT%H:%M:%S')
             plain = self._strip_ansi(message)
             self._log_file_handle.write(
                 f"{ts} [{level.upper()}] {plain}\n"
@@ -1101,7 +1101,7 @@ class FumitmPython:
             result = subprocess.run(
                 ['git', 'version'],
                 capture_output=True, text=True, timeout=5,
-            )
+            check=False)
             return 'Apple Git' in result.stdout
         except Exception:
             return False
@@ -1372,14 +1372,14 @@ class FumitmPython:
 
         for var_name, var_value in broken_vars:
             self.print_error(f"  {var_name}={var_value}")
-            self.print_error(f"    FILE DOES NOT EXIST")
+            self.print_error("    FILE DOES NOT EXIST")
             print()
 
         # Provide remediation steps
         self.print_info("To fix in your CURRENT shell session:")
         for var_name, _ in broken_vars:
             if var_name.startswith('JAVA_OPTS'):
-                self.print_info(f"  unset JAVA_OPTS  # (or edit to remove trustStore)")
+                self.print_info("  unset JAVA_OPTS  # (or edit to remove trustStore)")
             else:
                 self.print_info(f"  unset {var_name}")
         print()
@@ -1512,7 +1512,7 @@ class FumitmPython:
             try:
                 result = subprocess.run(
                     ['openssl', 'x509', '-in', cert_path, '-noout', '-fingerprint', '-sha256'],
-                    capture_output=True, text=True
+                    capture_output=True, text=True, check=False
                 )
                 if result.returncode == 0:
                     fingerprint = result.stdout.strip().split('=')[1]
@@ -1530,14 +1530,14 @@ class FumitmPython:
         if not java_home and self.command_exists('java'):
             try:
                 if platform.system() == 'Darwin' and os.path.exists('/usr/libexec/java_home'):
-                    result = subprocess.run(['/usr/libexec/java_home'], capture_output=True, text=True)
+                    result = subprocess.run(['/usr/libexec/java_home'], capture_output=True, text=True, check=False)
                     if result.returncode == 0:
                         java_home = result.stdout.strip()
 
                 if not java_home:
                     result = subprocess.run(
                         ['java', '-XshowSettings:properties', '-version'],
-                        capture_output=True, text=True, stderr=subprocess.STDOUT
+                        capture_output=True, text=True, stderr=subprocess.STDOUT, check=False
                     )
                     for line in result.stdout.splitlines():
                         if 'java.home' in line:
@@ -1586,7 +1586,7 @@ class FumitmPython:
                         ['/usr/libexec/java_home', '-V'],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.STDOUT,
-                        text=True
+                        text=True, check=False
                     )
                     for line in result.stdout.splitlines():
                         if line and '/' in line and '/Contents/Home' in line:
@@ -1618,7 +1618,7 @@ class FumitmPython:
                 result = subprocess.run(
                     ['update-alternatives', '--list', 'java'],
                     capture_output=True,
-                    text=True
+                    text=True, check=False
                 )
                 if result.returncode == 0:
                     for line in result.stdout.splitlines():
@@ -2155,14 +2155,14 @@ class FumitmPython:
         self.print_info("The proxy certificate needs to be obtained from your Windows host machine.")
         print()
         self.print_info("QUICKEST METHOD:")
-        self.print_info(f"1. On your Windows host, open PowerShell/Terminal and run:")
+        self.print_info("1. On your Windows host, open PowerShell/Terminal and run:")
         self.print_info(f"   {BLUE}warp-cli certs --no-paginate{NC}")
-        self.print_info(f"2. Copy the entire output (including BEGIN/END lines)")
-        self.print_info(f"3. Come back here and paste it")
+        self.print_info("2. Copy the entire output (including BEGIN/END lines)")
+        self.print_info("3. Come back here and paste it")
         print()
         self.print_info("ALTERNATIVE METHOD:")
-        self.print_info(f"1. Save the certificate to a file accessible from this container")
-        self.print_info(f"2. Run: ./fumitm.py --fix --cert-file /path/to/cert.pem")
+        self.print_info("1. Save the certificate to a file accessible from this container")
+        self.print_info("2. Run: ./fumitm.py --fix --cert-file /path/to/cert.pem")
         print()
         
         if self.auto_yes:
@@ -2241,7 +2241,7 @@ class FumitmPython:
         try:
             result = subprocess.run(
                 ['warp-cli', 'certs', '--no-paginate'],
-                capture_output=True, text=True
+                capture_output=True, text=True, check=False
             )
             if result.returncode != 0 or not result.stdout.strip():
                 self.print_error("Failed to get certificate from warp-cli")
@@ -2324,7 +2324,7 @@ class FumitmPython:
             result = subprocess.run(
                 ['security', 'find-certificate', '-c', 'certadmin', '-p',
                  '/Library/Keychains/System.keychain'],
-                capture_output=True, text=True
+                capture_output=True, text=True, check=False
             )
             if result.returncode == 0 and '-----BEGIN CERTIFICATE-----' in result.stdout:
                 certs.append(result.stdout.strip())
@@ -2342,7 +2342,7 @@ class FumitmPython:
             result = subprocess.run(
                 ['security', 'find-certificate', '-c', 'goskope', '-p',
                  '/Library/Keychains/System.keychain'],
-                capture_output=True, text=True
+                capture_output=True, text=True, check=False
             )
             if result.returncode == 0 and '-----BEGIN CERTIFICATE-----' in result.stdout:
                 certs.append(result.stdout.strip())
@@ -2436,7 +2436,7 @@ class FumitmPython:
         try:
             result = subprocess.run(
                 ['openssl', 'x509', '-noout', '-in', temp_cert_path],
-                capture_output=True
+                capture_output=True, check=False
             )
             if result.returncode != 0:
                 self.print_error("Retrieved file is not a valid PEM certificate")
@@ -2522,7 +2522,7 @@ class FumitmPython:
             return False
         try:
             result = subprocess.run(
-                ['openssl', 'x509', '-noout', '-in', tmp], capture_output=True
+                ['openssl', 'x509', '-noout', '-in', tmp], capture_output=True, check=False
             )
             return result.returncode == 0
         except Exception:
@@ -2644,7 +2644,7 @@ class FumitmPython:
             result = subprocess.run(
                 [keytool_bin, '-list', '-alias', alias,
                  '-keystore', keystore, '-storepass', 'changeit'],
-                capture_output=True
+                capture_output=True, check=False
             )
             return result.returncode == 0 and alias in result.stdout.decode()
         except Exception:
@@ -2671,7 +2671,7 @@ class FumitmPython:
                 [keytool_bin, '-import', '-trustcacerts', '-alias', alias,
                  '-file', cert_path, '-keystore', keystore, '-storepass', 'changeit',
                  '-noprompt'],
-                capture_output=True, text=True
+                capture_output=True, text=True, check=False
             )
             if result.returncode == 0:
                 self.print_info(f"    ✓ {label}: {alias} added successfully")
@@ -2760,7 +2760,7 @@ class FumitmPython:
         try:
             result = subprocess.run(
                 ['brew', '--prefix'],
-                capture_output=True, text=True
+                capture_output=True, text=True, check=False
             )
             prefix = result.stdout.strip()
             if result.returncode == 0 and prefix:
@@ -2791,7 +2791,7 @@ class FumitmPython:
         try:
             result = subprocess.run(
                 ['brew', 'list', 'ca-certificates'],
-                capture_output=True, text=True
+                capture_output=True, text=True, check=False
             )
             if result.returncode != 0:
                 self.print_debug("Homebrew ca-certificates formula not installed")
@@ -2846,7 +2846,7 @@ class FumitmPython:
         """
         result = subprocess.run(
             ['brew', 'postinstall', 'ca-certificates'],
-            capture_output=True, text=True
+            capture_output=True, text=True, check=False
         )
         if result.returncode != 0:
             self.print_error("brew postinstall ca-certificates failed")
@@ -3002,7 +3002,7 @@ class FumitmPython:
         try:
             result = subprocess.run(
                 ['npm', 'config', 'get', 'cafile'],
-                capture_output=True, text=True
+                capture_output=True, text=True, check=False
             )
             current_cafile = result.stdout.strip() if result.returncode == 0 else ""
         except Exception:
@@ -3024,7 +3024,7 @@ class FumitmPython:
                     self._safe_makedirs(os.path.dirname(npm_bundle))
                     self.create_bundle_with_system_certs(npm_bundle)
                     self._append_all_proxy_roots(npm_bundle)
-                    subprocess.run(['npm', 'config', 'set', 'cafile', npm_bundle])
+                    subprocess.run(['npm', 'config', 'set', 'cafile', npm_bundle], check=False)
                     self.print_info(f"Migrated npm cafile to: {npm_bundle}")
                 return
 
@@ -3041,7 +3041,7 @@ class FumitmPython:
                         self._safe_makedirs(os.path.dirname(npm_bundle))
                         self.create_bundle_with_system_certs(npm_bundle)
                         self._append_all_proxy_roots(npm_bundle)
-                        subprocess.run(['npm', 'config', 'set', 'cafile', npm_bundle])
+                        subprocess.run(['npm', 'config', 'set', 'cafile', npm_bundle], check=False)
                         self.print_info(f"Repointed npm cafile to managed bundle: {npm_bundle}")
                     return
 
@@ -3062,16 +3062,16 @@ class FumitmPython:
                         else:
                             self._safe_makedirs(os.path.dirname(npm_bundle))
                             # Create a full bundle with system certs
-                            if not self.create_bundle_with_system_certs(npm_bundle):
+                            if (not self.create_bundle_with_system_certs(npm_bundle)
+                                    and os.path.exists(current_cafile)):
                                 # Copy existing bundle if available
-                                if os.path.exists(current_cafile):
-                                    shutil.copy(current_cafile, npm_bundle)
-                                    self._fix_ownership(npm_bundle)
+                                shutil.copy(current_cafile, npm_bundle)
+                                self._fix_ownership(npm_bundle)
 
                             # Append certificate to bundle
                             self._append_all_proxy_roots(npm_bundle)
 
-                            subprocess.run(['npm', 'config', 'set', 'cafile', npm_bundle])
+                            subprocess.run(['npm', 'config', 'set', 'cafile', npm_bundle], check=False)
                             self.print_info(f"Created new npm cafile at {npm_bundle}")
                     else:
                         if not self.is_install_mode():
@@ -3094,7 +3094,7 @@ class FumitmPython:
                         self._safe_makedirs(os.path.dirname(npm_bundle))
                         self.create_bundle_with_system_certs(npm_bundle)
                         self._append_all_proxy_roots(npm_bundle)
-                        subprocess.run(['npm', 'config', 'set', 'cafile', npm_bundle])
+                        subprocess.run(['npm', 'config', 'set', 'cafile', npm_bundle], check=False)
                         self.print_info(f"Created and configured npm cafile at {npm_bundle}")
         else:
             self.print_info("Configuring npm certificate...")
@@ -3110,14 +3110,14 @@ class FumitmPython:
                     if not self.create_bundle_with_system_certs(npm_bundle):
                         self.print_warn("Could not find system CA bundle, creating new bundle with only proxy certificate")
                     self._append_all_proxy_roots(npm_bundle)
-                    subprocess.run(['npm', 'config', 'set', 'cafile', npm_bundle])
+                    subprocess.run(['npm', 'config', 'set', 'cafile', npm_bundle], check=False)
                     self.print_info(f"Configured npm cafile to: {npm_bundle}")
                     
                     # Verify the setting
                     try:
                         result = subprocess.run(
                             ['npm', 'config', 'get', 'cafile'],
-                            capture_output=True, text=True
+                            capture_output=True, text=True, check=False
                         )
                         verify_cafile = result.stdout.strip()
                         if verify_cafile == npm_bundle:
@@ -3139,7 +3139,7 @@ class FumitmPython:
 
         try:
             # Detect yarn version (v1 vs Berry/v2+)
-            result = subprocess.run(['yarn', '--version'], capture_output=True, text=True)
+            result = subprocess.run(['yarn', '--version'], capture_output=True, text=True, check=False)
             yarn_version = result.stdout.strip()
             if not yarn_version:
                 return
@@ -3154,7 +3154,7 @@ class FumitmPython:
                 delete_cmd = ['yarn', 'config', 'delete', 'cafile']
 
             result = subprocess.run(['yarn', 'config', 'get', config_key],
-                                   capture_output=True, text=True)
+                                   capture_output=True, text=True, check=False)
             current_cafile = result.stdout.strip()
 
             # Check if set to something problematic
@@ -3181,7 +3181,7 @@ class FumitmPython:
                 self.print_action(f"Would remove yarn {config_key} config")
                 self.print_action("NODE_EXTRA_CA_CERTS will handle certificate trust for yarn")
             else:
-                subprocess.run(delete_cmd, capture_output=True)
+                subprocess.run(delete_cmd, capture_output=True, check=False)
                 self.print_info(f"Removed yarn {config_key} config")
                 self.print_info("yarn will now use NODE_EXTRA_CA_CERTS for certificate trust")
         except Exception as e:
@@ -3198,7 +3198,7 @@ class FumitmPython:
 
         try:
             result = subprocess.run(['pnpm', 'config', 'get', 'cafile'],
-                                   capture_output=True, text=True)
+                                   capture_output=True, text=True, check=False)
             current_cafile = result.stdout.strip()
 
             if not current_cafile or current_cafile in ['undefined', '']:
@@ -3224,7 +3224,7 @@ class FumitmPython:
                 self.print_action("Would remove pnpm cafile config")
                 self.print_action("NODE_EXTRA_CA_CERTS will handle certificate trust for pnpm")
             else:
-                subprocess.run(['pnpm', 'config', 'delete', 'cafile'], capture_output=True)
+                subprocess.run(['pnpm', 'config', 'delete', 'cafile'], capture_output=True, check=False)
                 self.print_info("Removed pnpm cafile config")
                 self.print_info("pnpm will now use NODE_EXTRA_CA_CERTS for certificate trust")
         except Exception as e:
@@ -3620,7 +3620,7 @@ class FumitmPython:
         try:
             result = subprocess.run(
                 ['gcloud', 'config', 'get-value', 'core/custom_ca_certs_file'],
-                capture_output=True, text=True
+                capture_output=True, text=True, check=False
             )
             current_ca_file = result.stdout.strip() if result.returncode == 0 else ""
         except Exception:
@@ -3642,7 +3642,7 @@ class FumitmPython:
                     self._safe_makedirs(gcloud_cert_dir)
                     self.create_bundle_with_system_certs(gcloud_bundle)
                     self._append_all_proxy_roots(gcloud_bundle)
-                    subprocess.run(['gcloud', 'config', 'set', 'core/custom_ca_certs_file', gcloud_bundle], capture_output=True, timeout=30)
+                    subprocess.run(['gcloud', 'config', 'set', 'core/custom_ca_certs_file', gcloud_bundle], capture_output=True, timeout=30, check=False)
                     self.print_info(f"Repointed gcloud custom CA file to managed bundle: {gcloud_bundle}")
                     return ToolResult('gcloud', 'configured', 'Repointed suspicious gcloud CA file')
                 return ToolResult('gcloud', 'skipped', 'Dry run')
@@ -3699,7 +3699,8 @@ class FumitmPython:
             result = subprocess.run(
                 ['gcloud', 'config', 'set', 'core/custom_ca_certs_file', gcloud_bundle],
                 capture_output=True,
-                timeout=30  # Add timeout to prevent hanging
+                timeout=30,  # Add timeout to prevent hanging
+                check=False
             )
             if result.returncode == 0:
                 self.print_info("gcloud configured successfully")
@@ -3707,7 +3708,7 @@ class FumitmPython:
                 if needs_setup and not self.is_devcontainer():
                     self.print_info("Running gcloud diagnostics...")
                     try:
-                        subprocess.run(['gcloud', 'info', '--run-diagnostics'], timeout=10)
+                        subprocess.run(['gcloud', 'info', '--run-diagnostics'], timeout=10, check=False)
                     except subprocess.TimeoutExpired:
                         self.print_warn("gcloud diagnostics timed out, skipping")
                 return ToolResult('gcloud', 'configured', 'Configured gcloud certificate')
@@ -3722,7 +3723,7 @@ class FumitmPython:
         git_bundle = os.path.join(self.bundle_dir, "git/ca-bundle.pem")
         # Check current setting
         try:
-            result = subprocess.run(['git', 'config', '--global', 'http.sslCAInfo'], capture_output=True, text=True)
+            result = subprocess.run(['git', 'config', '--global', 'http.sslCAInfo'], capture_output=True, text=True, check=False)
             current_ca = result.stdout.strip() if result.returncode == 0 else ""
         except Exception:
             current_ca = ""
@@ -3773,7 +3774,7 @@ class FumitmPython:
         self._safe_makedirs(os.path.dirname(git_bundle))
         self.create_bundle_with_system_certs(git_bundle)
         self._append_all_proxy_roots(git_bundle)
-        subprocess.run(['git', 'config', '--global', 'http.sslCAInfo', git_bundle], capture_output=True, text=True)
+        subprocess.run(['git', 'config', '--global', 'http.sslCAInfo', git_bundle], capture_output=True, text=True, check=False)
         self.print_info(f"Configured git http.sslCAInfo to: {git_bundle}")
         return ToolResult('git', 'configured', f'Set http.sslCAInfo to {git_bundle}')
 
@@ -3931,7 +3932,7 @@ class FumitmPython:
         has_issues = False
         if self.command_exists('git'):
             try:
-                result = subprocess.run(['git', 'config', '--global', 'http.sslCAInfo'], capture_output=True, text=True)
+                result = subprocess.run(['git', 'config', '--global', 'http.sslCAInfo'], capture_output=True, text=True, check=False)
                 git_ca = result.stdout.strip() if result.returncode == 0 else ""
                 if git_ca:
                     self.print_info(f"  http.sslCAInfo is set to: {git_ca}")
@@ -3981,7 +3982,7 @@ class FumitmPython:
 
                 # Check if it's using SecureTransport (macOS system curl)
                 try:
-                    result = subprocess.run(['curl', '--version'], capture_output=True, text=True)
+                    result = subprocess.run(['curl', '--version'], capture_output=True, text=True, check=False)
                     if 'SecureTransport' in result.stdout:
                         self.print_info("  ✓ Using macOS system curl with SecureTransport (uses system keychain)")
                     elif os.environ.get('CURL_CA_BUNDLE'):
@@ -4096,7 +4097,7 @@ class FumitmPython:
                 ['jenv', 'versions', '--verbose'],
                 capture_output=True,
                 text=True,
-                timeout=10
+                timeout=10, check=False
             )
 
             if result.returncode != 0:
@@ -4118,7 +4119,7 @@ class FumitmPython:
                     if os.path.exists(cacerts) or os.path.exists(jre_cacerts):
                         java_homes.add(path)
 
-            return sorted(list(java_homes))
+            return sorted(java_homes)
         except Exception as e:
             self.print_debug(f"Error getting jenv Java homes: {e}")
             return []
@@ -4362,7 +4363,7 @@ class FumitmPython:
         try:
             result = subprocess.run(
                 ['podman', 'machine', 'list'],
-                capture_output=True, text=True
+                capture_output=True, text=True, check=False
             )
             return 'Currently running' in result.stdout
         except Exception:
@@ -4375,7 +4376,7 @@ class FumitmPython:
                 result = subprocess.run(
                     ['podman', 'machine', 'ssh',
                      f'test -f /etc/pki/ca-trust/source/anchors/{cert_name}.pem'],
-                    capture_output=True
+                    capture_output=True, check=False
                 )
                 if result.returncode != 0:
                     return False
@@ -4399,14 +4400,14 @@ class FumitmPython:
                 result = subprocess.run(
                     ['podman', 'machine', 'ssh',
                      f'sudo tee /etc/pki/ca-trust/source/anchors/{cert_name}.pem'],
-                    input=cert_content, text=True, capture_output=True
+                    input=cert_content, text=True, capture_output=True, check=False
                 )
                 if result.returncode != 0:
                     return False, 'Failed to copy certificate into VM'
 
             result = subprocess.run(
                 ['podman', 'machine', 'ssh', 'sudo update-ca-trust'],
-                capture_output=True
+                capture_output=True, check=False
             )
             if result.returncode == 0:
                 return True, 'Certificate installed in Podman VM'
@@ -4486,7 +4487,7 @@ class FumitmPython:
                 result = subprocess.run(
                     ['rdctl', 'shell', 'test', '-f',
                      f'/usr/local/share/ca-certificates/{cert_name}.crt'],
-                    capture_output=True
+                    capture_output=True, check=False
                 )
                 if result.returncode != 0:
                     return False
@@ -4507,14 +4508,14 @@ class FumitmPython:
                 result = subprocess.run(
                     ['rdctl', 'shell', 'sudo', 'tee',
                      f'/usr/local/share/ca-certificates/{cert_name}.crt'],
-                    input=cert_content, text=True, capture_output=True
+                    input=cert_content, text=True, capture_output=True, check=False
                 )
                 if result.returncode != 0:
                     return False, 'Failed to copy certificate into VM'
 
             result = subprocess.run(
                 ['rdctl', 'shell', 'sudo', 'update-ca-certificates'],
-                capture_output=True
+                capture_output=True, check=False
             )
             if result.returncode == 0:
                 return True, 'Certificate installed in Rancher Desktop VM'
@@ -4539,7 +4540,7 @@ class FumitmPython:
         vm_is_running = False
         vm_needs_cert = False
         try:
-            result = subprocess.run(['rdctl', 'version'], capture_output=True, text=True)
+            result = subprocess.run(['rdctl', 'version'], capture_output=True, text=True, check=False)
             vm_is_running = result.returncode == 0
             if vm_is_running:
                 vm_needs_cert = not self._check_cert_in_rancher_vm()
@@ -4600,7 +4601,7 @@ class FumitmPython:
 
         # Check if any emulator is running
         try:
-            result = subprocess.run(['adb', 'devices'], capture_output=True, text=True)
+            result = subprocess.run(['adb', 'devices'], capture_output=True, text=True, check=False)
             running_devices = sum(1 for line in result.stdout.splitlines() if 'emulator-' in line)
 
             if running_devices == 0:
@@ -4625,14 +4626,14 @@ class FumitmPython:
                 self.print_info("Installing certificate on Android emulator...")
 
                 # Restart ADB with root
-                result = subprocess.run(['adb', 'root'], capture_output=True)
+                result = subprocess.run(['adb', 'root'], capture_output=True, check=False)
                 if result.returncode != 0:
                     self.print_error("Failed to restart ADB with root permissions")
                     self.print_info("Make sure your emulator doesn't have Google Play Store")
                     return ToolResult('android', 'failed', 'Failed to restart ADB with root permissions')
 
                 # Remount system partition
-                result = subprocess.run(['adb', 'remount'], capture_output=True)
+                result = subprocess.run(['adb', 'remount'], capture_output=True, check=False)
                 if result.returncode != 0:
                     self.print_error("Failed to remount system partition")
                     self.print_info("Make sure emulator was started with -writable-system flag")
@@ -4643,17 +4644,17 @@ class FumitmPython:
                 for cert_name, cert_path in self._all_container_certs():
                     dest = f'/system/etc/security/cacerts/{cert_name}.pem'
                     result = subprocess.run(
-                        ['adb', 'push', cert_path, dest], capture_output=True
+                        ['adb', 'push', cert_path, dest], capture_output=True, check=False
                     )
                     if result.returncode != 0:
                         push_failed = True
                         break
                     subprocess.run(
-                        ['adb', 'shell', 'chmod', '644', dest], capture_output=True
+                        ['adb', 'shell', 'chmod', '644', dest], capture_output=True, check=False
                     )
                 if not push_failed:
                     self.print_info("Certificate installed. Rebooting emulator...")
-                    subprocess.run(['adb', 'reboot'], capture_output=True)
+                    subprocess.run(['adb', 'reboot'], capture_output=True, check=False)
                     self.print_info("Android emulator certificate installed successfully")
                     return ToolResult('android', 'configured', 'Certificate installed on emulator')
                 else:
@@ -4669,7 +4670,7 @@ class FumitmPython:
                 result = subprocess.run(
                     ['colima', 'ssh', '--', 'test', '-f',
                      f'/usr/local/share/ca-certificates/{cert_name}.crt'],
-                    capture_output=True
+                    capture_output=True, check=False
                 )
                 if result.returncode != 0:
                     return False
@@ -4690,14 +4691,14 @@ class FumitmPython:
                 result = subprocess.run(
                     ['colima', 'ssh', '--', 'sudo', 'tee',
                      f'/usr/local/share/ca-certificates/{cert_name}.crt'],
-                    input=cert_content, text=True, capture_output=True
+                    input=cert_content, text=True, capture_output=True, check=False
                 )
                 if result.returncode != 0:
                     return False, 'Failed to copy certificate into VM'
 
             result = subprocess.run(
                 ['colima', 'ssh', '--', 'sudo', 'update-ca-certificates'],
-                capture_output=True
+                capture_output=True, check=False
             )
             if result.returncode == 0:
                 return True, 'Certificate installed in Colima VM'
@@ -4723,7 +4724,7 @@ class FumitmPython:
         vm_is_running = False
         vm_needs_cert = False
         try:
-            status_result = subprocess.run(['colima', 'status'], capture_output=True)
+            status_result = subprocess.run(['colima', 'status'], capture_output=True, check=False)
             vm_is_running = (status_result.returncode == 0)
             if vm_is_running:
                 vm_needs_cert = not self._check_cert_in_colima_vm()
@@ -4780,7 +4781,7 @@ class FumitmPython:
         try:
             result = subprocess.run(
                 ['docker', 'info'],
-                capture_output=True, text=True, timeout=10
+                capture_output=True, text=True, timeout=10, check=False
             )
             return result.returncode == 0
         except Exception:
@@ -4802,12 +4803,13 @@ class FumitmPython:
             try:
                 result = subprocess.run(
                     ['docker', 'image', 'inspect', image],
-                    capture_output=True, timeout=5
+                    capture_output=True, timeout=5, check=False
                 )
                 if result.returncode == 0:
                     self.print_debug(f"Using locally cached image: {image}")
                     return image
             except Exception:
+                self.print_debug(f"Image inspect failed for {image}")
                 continue
         return None
 
@@ -4827,7 +4829,7 @@ class FumitmPython:
             try:
                 pull = subprocess.run(
                     ['docker', 'pull', 'alpine:latest'],
-                    capture_output=True, timeout=30
+                    capture_output=True, timeout=30, check=False
                 )
                 if pull.returncode == 0:
                     image = 'alpine:latest'
@@ -4844,7 +4846,7 @@ class FumitmPython:
         kwargs = {'capture_output': True, 'text': True, 'timeout': timeout}
         if stdin_data is not None:
             kwargs['input'] = stdin_data
-        return subprocess.run(cmd, **kwargs)
+        return subprocess.run(cmd, **kwargs, check=False)
 
     def _check_cert_in_docker_vm(self):
         """Check whether the proxy CA cert exists in the Docker VM.
@@ -4920,7 +4922,7 @@ class FumitmPython:
             if self.command_exists(tool):
                 try:
                     result = subprocess.run(
-                        cmd, capture_output=True, timeout=30
+                        cmd, capture_output=True, timeout=30, check=False
                     )
                     if result.returncode == 0:
                         self.print_info("Docker engine restarted")
@@ -5091,7 +5093,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                 try:
                     proc_result = subprocess.run(
                         ['node', '-e', node_script],
-                        capture_output=True, text=True
+                        capture_output=True, text=True, check=False
                     )
                     
                     if proc_result.returncode == 0:
@@ -5155,7 +5157,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     # Check curl version for SecureTransport
                     version_result = subprocess.run(
                         ['curl', '--version'],
-                        capture_output=True, text=True
+                        capture_output=True, text=True, check=False
                     )
                     self.print_debug(f"curl version: {version_result.stdout.splitlines()[0]}")
                     
@@ -5163,12 +5165,12 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     if self.is_debug_mode():
                         curl_result = subprocess.run(
                             ['curl', '-v', '-s', '-o', '/dev/null', test_url],
-                            capture_output=True, text=True
+                            capture_output=True, text=True, check=False
                         )
                     else:
                         curl_result = subprocess.run(
                             ['curl', '-s', '-o', '/dev/null', test_url],
-                            capture_output=True
+                            capture_output=True, check=False
                         )
                     
                     if curl_result.returncode == 0:
@@ -5198,12 +5200,12 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     if self.is_debug_mode():
                         wget_result = subprocess.run(
                             ['wget', '--debug', '-O', '/dev/null', test_url],
-                            capture_output=True, text=True
+                            capture_output=True, text=True, check=False
                         )
                     else:
                         wget_result = subprocess.run(
                             ['wget', '-q', '-O', '/dev/null', test_url],
-                            capture_output=True
+                            capture_output=True, check=False
                         )
                     
                     if wget_result.returncode == 0:
@@ -5235,7 +5237,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     # SSL issues.
                     aws_result = subprocess.run(
                         ['aws', '--no-sign-request', 'sts', 'get-caller-identity'],
-                        capture_output=True, text=True, timeout=15
+                        capture_output=True, text=True, timeout=15, check=False
                     )
 
                     stderr_lower = aws_result.stderr.lower()
@@ -5271,7 +5273,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     # to succeed.
                     gcloud_result = subprocess.run(
                         ['gcloud', 'projects', 'list', '--limit=1'],
-                        capture_output=True, text=True, timeout=15
+                        capture_output=True, text=True, timeout=15, check=False
                     )
 
                     # Check for SSL-specific errors in stderr
@@ -5310,7 +5312,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
         try:
             result = subprocess.run(
                 ['brew', 'list', 'ca-certificates'],
-                capture_output=True, text=True
+                capture_output=True, text=True, check=False
             )
             if result.returncode != 0:
                 self.print_info(
@@ -5386,7 +5388,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             # Check npm
             if self.command_exists('npm'):
                 try:
-                    result = subprocess.run(['npm', 'config', 'get', 'cafile'], capture_output=True, text=True)
+                    result = subprocess.run(['npm', 'config', 'get', 'cafile'], capture_output=True, text=True, check=False)
                     npm_cafile = result.stdout.strip() if result.returncode == 0 else ""
                     
                     if npm_cafile and npm_cafile not in ["null", "undefined"]:
@@ -5418,13 +5420,13 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             # Check yarn for stale cafile config
             if self.command_exists('yarn'):
                 try:
-                    result = subprocess.run(['yarn', '--version'], capture_output=True, text=True)
+                    result = subprocess.run(['yarn', '--version'], capture_output=True, text=True, check=False)
                     yarn_version = result.stdout.strip()
                     is_berry = yarn_version and yarn_version[0] in ('2', '3', '4')
                     config_key = 'httpsCaFilePath' if is_berry else 'cafile'
 
                     result = subprocess.run(['yarn', 'config', 'get', config_key],
-                                           capture_output=True, text=True)
+                                           capture_output=True, text=True, check=False)
                     yarn_cafile = result.stdout.strip()
 
                     if yarn_cafile and yarn_cafile not in ['undefined', '']:
@@ -5456,7 +5458,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             if self.command_exists('pnpm'):
                 try:
                     result = subprocess.run(['pnpm', 'config', 'get', 'cafile'],
-                                           capture_output=True, text=True)
+                                           capture_output=True, text=True, check=False)
                     pnpm_cafile = result.stdout.strip()
 
                     if pnpm_cafile and pnpm_cafile not in ['undefined', '']:
@@ -5503,15 +5505,15 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                 # a required root (e.g. the Aikido supplemental root) leaves uv
                 # broken even though Python itself works, so flag it explicitly.
                 ssl_cert_file = os.environ.get('SSL_CERT_FILE', '')
-                if ssl_cert_file and os.path.exists(ssl_cert_file):
-                    if not self._status_roots_present(temp_warp_cert, ssl_cert_file):
-                        self.print_warn(
-                            f"  ✗ SSL_CERT_FILE ({ssl_cert_file}) is missing a required root"
-                        )
-                        self.print_action(
-                            "    Run with --fix to add all roots (needed by uv/rustls clients)"
-                        )
-                        has_issues = True
+                if (ssl_cert_file and os.path.exists(ssl_cert_file)
+                        and not self._status_roots_present(temp_warp_cert, ssl_cert_file)):
+                    self.print_warn(
+                        f"  ✗ SSL_CERT_FILE ({ssl_cert_file}) is missing a required root"
+                    )
+                    self.print_action(
+                        "    Run with --fix to add all roots (needed by uv/rustls clients)"
+                    )
+                    has_issues = True
             else:
                 # Python doesn't trust system cert, check environment variables
                 python_configured = False
@@ -5538,15 +5540,15 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                 ssl_cert_file = os.environ.get('SSL_CERT_FILE', '')
                 if ssl_cert_file:
                     self.print_info(f"  SSL_CERT_FILE is set to: {ssl_cert_file}")
-                    if os.path.exists(ssl_cert_file):
-                        if self._status_roots_present(temp_warp_cert, ssl_cert_file):
-                            self.print_info("  ✓ SSL_CERT_FILE contains current certificate")
-                            suspicious, reason = self.is_suspicious_full_bundle(ssl_cert_file, None)
-                            if suspicious:
-                                self.print_warn(f"  ⚠ SSL_CERT_FILE looks suspiciously small ({reason})")
-                                self.print_action("    Run with --fix to repoint to a full CA bundle")
-                                has_issues = True
-                            python_configured = True
+                    if (os.path.exists(ssl_cert_file)
+                            and self._status_roots_present(temp_warp_cert, ssl_cert_file)):
+                        self.print_info("  ✓ SSL_CERT_FILE contains current certificate")
+                        suspicious, reason = self.is_suspicious_full_bundle(ssl_cert_file, None)
+                        if suspicious:
+                            self.print_warn(f"  ⚠ SSL_CERT_FILE looks suspiciously small ({reason})")
+                            self.print_action("    Run with --fix to repoint to a full CA bundle")
+                            has_issues = True
+                        python_configured = True
                 
                 if not python_configured:
                     if not requests_ca_bundle and not ssl_cert_file:
@@ -5576,7 +5578,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                 try:
                     result = subprocess.run(
                         ['gcloud', 'config', 'get-value', 'core/custom_ca_certs_file'],
-                        capture_output=True, text=True
+                        capture_output=True, text=True, check=False
                     )
                     gcloud_ca = result.stdout.strip() if result.returncode == 0 else ""
 
@@ -5600,7 +5602,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                 try:
                     result = subprocess.run(
                         ['gcloud', 'config', 'get-value', 'core/custom_ca_certs_file'],
-                        capture_output=True, text=True
+                        capture_output=True, text=True, check=False
                     )
                     gcloud_ca = result.stdout.strip() if result.returncode == 0 else ""
 
@@ -5626,7 +5628,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                 try:
                     result = subprocess.run(
                         ['gcloud', 'config', 'get-value', 'core/custom_ca_certs_file'],
-                        capture_output=True, text=True
+                        capture_output=True, text=True, check=False
                     )
                     gcloud_ca = result.stdout.strip() if result.returncode == 0 else ""
 
@@ -5682,7 +5684,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                 result = subprocess.run(
                     ['keytool', '-list', '-alias', self.provider['keytool_alias'],
                      '-keystore', cacerts, '-storepass', 'changeit'],
-                    capture_output=True
+                    capture_output=True, check=False
                 )
                 if result.returncode == 0:
                     self.print_info(f"  ✓ {version_name}: Certificate installed")
@@ -5723,7 +5725,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                 result = subprocess.run(
                     ['keytool', '-list', '-alias', self.provider['keytool_alias'],
                      '-keystore', cacerts, '-storepass', 'changeit'],
-                    capture_output=True
+                    capture_output=True, check=False
                 )
                 if result.returncode == 0 and self.provider['keytool_alias'] in result.stdout.decode():
                     self.print_info(f"    ✓ {version_name}: Certificate installed")
@@ -5776,7 +5778,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     result = subprocess.run(
                         [dbeaver_keytool, '-list', '-alias', self.provider['keytool_alias'],
                          '-keystore', dbeaver_cacerts, '-storepass', 'changeit'],
-                        capture_output=True
+                        capture_output=True, check=False
                     )
                     if result.returncode == 0 and self.provider['keytool_alias'] in result.stdout.decode():
                         self.print_info("  ✓ DBeaver keystore contains proxy certificate")
@@ -5849,12 +5851,12 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
 
             # Check VM status if running
             try:
-                result = subprocess.run(['podman', 'machine', 'list'], capture_output=True, text=True)
+                result = subprocess.run(['podman', 'machine', 'list'], capture_output=True, text=True, check=False)
                 if 'Currently running' in result.stdout:
                     # VM is running - also check certificate in VM
                     result = subprocess.run(
                         ['podman', 'machine', 'ssh', f'test -f /etc/pki/ca-trust/source/anchors/{self.provider["container_cert_name"]}.pem'],
-                        capture_output=True
+                        capture_output=True, check=False
                     )
                     if result.returncode == 0:
                         self.print_info("  ✓ Certificate installed in running VM")
@@ -5891,7 +5893,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
 
             # Check VM status if running
             try:
-                version_result = subprocess.run(['rdctl', 'version'], capture_output=True, text=True)
+                version_result = subprocess.run(['rdctl', 'version'], capture_output=True, text=True, check=False)
                 if version_result.returncode == 0:
                     if self._check_cert_in_rancher_vm():
                         self.print_info("  ✓ Certificate installed in running VM")
@@ -5945,7 +5947,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
         has_issues = False
         if self.command_exists('adb') and self.command_exists('emulator'):
             try:
-                result = subprocess.run(['adb', 'devices'], capture_output=True, text=True)
+                result = subprocess.run(['adb', 'devices'], capture_output=True, text=True, check=False)
                 running_emulators = sum(1 for line in result.stdout.splitlines() if 'emulator-' in line)
                 if running_emulators > 0:
                     self.print_info("  - Android emulator detected (manual installation available)")
@@ -5981,7 +5983,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
 
             # Check VM status if running
             try:
-                status_result = subprocess.run(['colima', 'status'], capture_output=True)
+                status_result = subprocess.run(['colima', 'status'], capture_output=True, check=False)
                 if status_result.returncode == 0:
                     if self._check_cert_in_colima_vm():
                         self.print_info("  ✓ Certificate installed in running VM")
@@ -6010,7 +6012,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             try:
                 result = subprocess.run(
                     ['warp-cli', 'certs', '--no-paginate'],
-                    capture_output=True, text=True
+                    capture_output=True, text=True, check=False
                 )
                 if result.returncode == 0 and result.stdout.strip():
                     with tempfile.NamedTemporaryFile(mode='w', suffix='.pem', delete=False) as tf:
@@ -6054,7 +6056,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             self.print_status(f"{provider_name} Connection:")
             if self.command_exists('warp-cli'):
                 try:
-                    result = subprocess.run(['warp-cli', 'status'], capture_output=True, text=True)
+                    result = subprocess.run(['warp-cli', 'status'], capture_output=True, text=True, check=False)
                     warp_status = result.stdout if result.returncode == 0 else "unknown"
                     if "Connected" in warp_status:
                         self.print_info(f"  ✓ {short} is connected")
@@ -6079,7 +6081,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             try:
                 result = subprocess.run(
                     ['pgrep', '-f', proc_pattern],
-                    capture_output=True, text=True
+                    capture_output=True, text=True, check=False
                 )
                 if result.returncode == 0 and result.stdout.strip():
                     self.print_info(f"  ✓ {proc_label} is running")
@@ -6135,7 +6137,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
         try:
             result = subprocess.run(
                 ['openssl', 'x509', '-noout', '-checkend', '86400', '-in', temp_warp_cert],
-                capture_output=True
+                capture_output=True, check=False
             )
             if result.returncode == 0:
                 self.print_info(f"  ✓ {short} certificate is valid")
@@ -6156,24 +6158,24 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                 
                 # Check NODE_EXTRA_CA_CERTS
                 node_extra_ca_certs = os.environ.get('NODE_EXTRA_CA_CERTS', '')
-                if node_extra_ca_certs and os.path.exists(node_extra_ca_certs):
-                    if self.certificate_exists_in_file(temp_warp_cert, node_extra_ca_certs):
-                        cert_locations.append(f"    - {node_extra_ca_certs} (NODE_EXTRA_CA_CERTS)")
-                        cert_found = True
+                if (node_extra_ca_certs and os.path.exists(node_extra_ca_certs)
+                        and self.certificate_exists_in_file(temp_warp_cert, node_extra_ca_certs)):
+                    cert_locations.append(f"    - {node_extra_ca_certs} (NODE_EXTRA_CA_CERTS)")
+                    cert_found = True
                 
                 # Check REQUESTS_CA_BUNDLE
                 requests_ca_bundle = os.environ.get('REQUESTS_CA_BUNDLE', '')
-                if requests_ca_bundle and os.path.exists(requests_ca_bundle):
-                    if self.certificate_exists_in_file(temp_warp_cert, requests_ca_bundle):
-                        cert_locations.append(f"    - {requests_ca_bundle} (REQUESTS_CA_BUNDLE)")
-                        cert_found = True
+                if (requests_ca_bundle and os.path.exists(requests_ca_bundle)
+                        and self.certificate_exists_in_file(temp_warp_cert, requests_ca_bundle)):
+                    cert_locations.append(f"    - {requests_ca_bundle} (REQUESTS_CA_BUNDLE)")
+                    cert_found = True
                 
                 # Check SSL_CERT_FILE
                 ssl_cert_file = os.environ.get('SSL_CERT_FILE', '')
-                if ssl_cert_file and os.path.exists(ssl_cert_file):
-                    if self.certificate_exists_in_file(temp_warp_cert, ssl_cert_file):
-                        cert_locations.append(f"    - {ssl_cert_file} (SSL_CERT_FILE)")
-                        cert_found = True
+                if (ssl_cert_file and os.path.exists(ssl_cert_file)
+                        and self.certificate_exists_in_file(temp_warp_cert, ssl_cert_file)):
+                    cert_locations.append(f"    - {ssl_cert_file} (SSL_CERT_FILE)")
+                    cert_found = True
                 
                 if cert_found:
                     self.print_info(f"  ✓ {short} certificate found in:")

--- a/fumitm_windows.py
+++ b/fumitm_windows.py
@@ -1,20 +1,17 @@
 #!/usr/bin/env python3
 
-import os
-import sys
-import subprocess
-import tempfile
-import shutil
 import argparse
+import os
 import platform
-import json
+import shutil
 import ssl
-import hashlib
-import urllib.request
+import subprocess
+import sys
+import tempfile
 import urllib.error
+import urllib.request
 import winreg
 from pathlib import Path
-from datetime import datetime
 
 # Version and metadata
 __description__ = "MITM Certificate Fixer Upper for Windows"
@@ -59,7 +56,7 @@ def get_version_info():
             cwd=script_dir,
             capture_output=True,
             text=True,
-        )
+        check=False)
 
         if result.returncode == 0:
             # Get commit hash (short)
@@ -68,7 +65,7 @@ def get_version_info():
                 cwd=script_dir,
                 capture_output=True,
                 text=True,
-            )
+            check=False)
             if result.returncode == 0:
                 version_info["commit"] = result.stdout.strip()
 
@@ -78,7 +75,7 @@ def get_version_info():
                 cwd=script_dir,
                 capture_output=True,
                 text=True,
-            )
+            check=False)
             if result.returncode == 0:
                 version_info["date"] = result.stdout.strip()
 
@@ -88,7 +85,7 @@ def get_version_info():
                 cwd=script_dir,
                 capture_output=True,
                 text=True,
-            )
+            check=False)
             if result.returncode == 0:
                 version_info["branch"] = result.stdout.strip()
 
@@ -98,7 +95,7 @@ def get_version_info():
                 cwd=script_dir,
                 capture_output=True,
                 text=True,
-            )
+            check=False)
             if result.returncode == 0 and result.stdout.strip():
                 version_info["dirty"] = True
 
@@ -109,7 +106,7 @@ def get_version_info():
                 capture_output=True,
                 text=True,
                 stderr=subprocess.DEVNULL,
-            )
+            check=False)
             if result.returncode == 0 and result.stdout.strip():
                 version_info["version"] = result.stdout.strip()
             else:
@@ -119,7 +116,7 @@ def get_version_info():
                     cwd=script_dir,
                     capture_output=True,
                     text=True,
-                )
+                check=False)
                 if result.returncode == 0 and result.stdout.strip():
                     count = result.stdout.strip()
                     version_info["version"] = f"0.{count}.0"
@@ -337,7 +334,7 @@ class FumitmWindows:
                 ["tasklist", "/FI", "IMAGENAME eq STAgent.exe"],
                 capture_output=True,
                 text=True,
-            )
+            check=False)
             if result.returncode == 0 and "STAgent.exe" in result.stdout:
                 return True
         except Exception:
@@ -388,7 +385,7 @@ class FumitmWindows:
             return list(self.tools_registry.keys())
 
         selected = []
-        for tool_key, tool_info in self.tools_registry.items():
+        for tool_key in self.tools_registry:
             if self.should_process_tool(tool_key):
                 selected.append(tool_key)
 
@@ -522,7 +519,7 @@ class FumitmWindows:
                 ["warp-cli", "certs", "--no-paginate"],
                 capture_output=True,
                 text=True,
-            )
+            check=False)
 
             if result.returncode != 0 or not result.stdout.strip():
                 self.print_error("Failed to get certificate from warp-cli")
@@ -626,7 +623,7 @@ class FumitmWindows:
                         ["warp-cli", "status"],
                         capture_output=True,
                         text=True,
-                    )
+                    check=False)
                     warp_status = result.stdout if result.returncode == 0 else "unknown"
                     if "Connected" in warp_status:
                         self.print_info(f"  ✓ {short_name} is connected")
@@ -648,7 +645,7 @@ class FumitmWindows:
                 ["tasklist", "/FI", "IMAGENAME eq STAgent.exe"],
                 capture_output=True,
                 text=True,
-            )
+            check=False)
             if result.returncode == 0 and "STAgent.exe" in result.stdout:
                 self.print_info("  ✓ STAgent is running")
                 return False
@@ -706,7 +703,7 @@ class FumitmWindows:
                     ],
                     capture_output=True,
                     text=True,
-                )
+                check=False)
                 if result.returncode == 0:
                     fingerprint = result.stdout.strip().split("=")[1]
                     if cert_path == CERT_PATH:
@@ -733,7 +730,7 @@ class FumitmWindows:
                     ["powershell", "-Command", ps_command],
                     capture_output=True,
                     text=True,
-                )
+                check=False)
 
                 if result.returncode == 0 and result.stdout.strip():
                     fingerprint = result.stdout.strip()
@@ -785,23 +782,22 @@ class FumitmWindows:
         existing_bundle = self.find_existing_bundle(tool_name)
 
         # Check if bundle already exists and is current
-        if os.path.exists(bundle_path):
-            if self.certificate_exists_in_file(CERT_PATH, bundle_path):
-                self.print_debug(
-                    f"{tool_name} bundle already contains current certificate"
-                )
-                # Bundle is healthy — still ensure all env vars are set in the registry,
-                # since they may have been missed on a previous run.
-                if env_vars:
-                    for env_var in env_vars:
-                        if not self.get_environment_variable(env_var):
-                            if not self.is_install_mode():
-                                self.print_action(
-                                    f"Would set {env_var} to {bundle_path}"
-                                )
-                            else:
-                                self.set_environment_variable(env_var, bundle_path)
-                return bundle_path
+        if os.path.exists(bundle_path) and self.certificate_exists_in_file(CERT_PATH, bundle_path):
+            self.print_debug(
+                f"{tool_name} bundle already contains current certificate"
+            )
+            # Bundle is healthy — still ensure all env vars are set in the registry,
+            # since they may have been missed on a previous run.
+            if env_vars:
+                for env_var in env_vars:
+                    if not self.get_environment_variable(env_var):
+                        if not self.is_install_mode():
+                            self.print_action(
+                                f"Would set {env_var} to {bundle_path}"
+                            )
+                        else:
+                            self.set_environment_variable(env_var, bundle_path)
+            return bundle_path
 
         # Handle existing bundle
         if existing_bundle:
@@ -837,7 +833,7 @@ class FumitmWindows:
                         self.append_certificate_if_missing(CERT_PATH, bundle_path)
                     else:
                         self.print_debug(
-                            f"Copied bundle already contains current certificate, skipping append"
+                            "Copied bundle already contains current certificate, skipping append"
                         )
                 else:
                     return None
@@ -1051,7 +1047,7 @@ class FumitmWindows:
             HWND_BROADCAST = 0xFFFF
             WM_SETTINGCHANGE = 0x001A
             SMTO_ABORTIFHUNG = 0x0002
-            result = ctypes.windll.user32.SendMessageTimeoutW(
+            ctypes.windll.user32.SendMessageTimeoutW(
                 HWND_BROADCAST,
                 WM_SETTINGCHANGE,
                 0,
@@ -1120,7 +1116,7 @@ class FumitmWindows:
             """
 
             result = subprocess.run(
-                ["powershell", "-Command", ps_command], capture_output=True, text=True
+                ["powershell", "-Command", ps_command], capture_output=True, text=True, check=False
             )
 
             if result.returncode == 0:
@@ -1156,7 +1152,7 @@ class FumitmWindows:
             """
 
             result = subprocess.run(
-                ["powershell", "-Command", ps_command], capture_output=True, text=True
+                ["powershell", "-Command", ps_command], capture_output=True, text=True, check=False
             )
 
             return result.returncode == 0 and "Found" in result.stdout
@@ -1194,11 +1190,11 @@ class FumitmWindows:
             result = subprocess.run(
                 ["openssl", "x509", "-noout", "-in", temp_cert_path],
                 capture_output=True,
-            )
+            check=False)
             if result.returncode == 0:
                 self.print_debug("Certificate verified with openssl")
             else:
-                raise Exception("OpenSSL verification failed")
+                raise RuntimeError("OpenSSL verification failed")
         except Exception as e:
             self.print_debug(
                 f"OpenSSL not available, trying PowerShell verification: {e}"
@@ -1225,7 +1221,7 @@ class FumitmWindows:
                     ["powershell", "-Command", ps_command],
                     capture_output=True,
                     text=True,
-                )
+                check=False)
 
                 if result.returncode != 0:
                     self.print_error("Retrieved file is not a valid PEM certificate")
@@ -1299,7 +1295,7 @@ class FumitmWindows:
             """
 
             result = subprocess.run(
-                ["powershell", "-Command", ps_command], capture_output=True, text=True
+                ["powershell", "-Command", ps_command], capture_output=True, text=True, check=False
             )
 
             if result.returncode == 0 and result.stdout.strip():
@@ -1346,7 +1342,7 @@ class FumitmWindows:
                             ["powershell", "-Command", ps_command],
                             capture_output=True,
                             text=True,
-                        )
+                        check=False)
 
                         if result.returncode == 0:
                             self.print_info(
@@ -1383,7 +1379,7 @@ class FumitmWindows:
                     self.append_certificate_if_missing(CERT_PATH, node_extra_ca_certs)
             else:
                 self.print_info(
-                    f"NODE_EXTRA_CA_CERTS already contains current certificate"
+                    "NODE_EXTRA_CA_CERTS already contains current certificate"
                 )
         else:
             # Use consistent bundle management
@@ -1405,7 +1401,7 @@ class FumitmWindows:
                 ["npm", "config", "get", "cafile"],
                 capture_output=True,
                 text=True,
-            )
+            check=False)
             current_cafile = result.stdout.strip() if result.returncode == 0 else ""
         except Exception:
             current_cafile = ""
@@ -1492,7 +1488,7 @@ class FumitmWindows:
                     ["gcloud", "config", "get-value", "core/custom_ca_certs_file"],
                     capture_output=True,
                     text=True,
-                )
+                check=False)
                 current_ca_file = (
                     result.stdout.strip() if result.returncode == 0 else ""
                 )
@@ -1515,7 +1511,7 @@ class FumitmWindows:
                                     "core/custom_ca_certs_file",
                                 ],
                                 capture_output=True,
-                            )
+                            check=False)
                             self.print_info(
                                 "Configured gcloud to use Windows certificate store"
                             )
@@ -1541,7 +1537,7 @@ class FumitmWindows:
                 ["gcloud", "config", "get-value", "core/custom_ca_certs_file"],
                 capture_output=True,
                 text=True,
-            )
+            check=False)
             current_ca_file = result.stdout.strip() if result.returncode == 0 else ""
         except Exception:
             current_ca_file = ""
@@ -1565,7 +1561,7 @@ class FumitmWindows:
             result = subprocess.run(
                 ["gcloud", "config", "set", "core/custom_ca_certs_file", bundle_path],
                 capture_output=True,
-            )
+            check=False)
             if result.returncode == 0:
                 self.print_info(f"gcloud configured to use CA bundle: {bundle_path}")
             else:
@@ -1588,7 +1584,7 @@ class FumitmWindows:
             try:
                 # Try to find Java installation
                 result = subprocess.run(
-                    ["where", "java"], capture_output=True, text=True
+                    ["where", "java"], capture_output=True, text=True, check=False
                 )
                 if result.returncode == 0:
                     java_path = result.stdout.strip().split("\n")[0]
@@ -1630,7 +1626,7 @@ class FumitmWindows:
                     "changeit",
                 ],
                 capture_output=True,
-            )
+            check=False)
             if (
                 result.returncode == 0
                 and self.get_keytool_alias() in result.stdout.decode()
@@ -1664,7 +1660,7 @@ class FumitmWindows:
                     "-noprompt",
                 ],
                 capture_output=True,
-            )
+            check=False)
             if result.returncode == 0:
                 self.print_info("Certificate added to Java keystore successfully")
             else:
@@ -1755,7 +1751,7 @@ class FumitmWindows:
                 ["podman", "machine", "list"],
                 capture_output=True,
                 text=True,
-            )
+            check=False)
             if "Currently running" not in result.stdout:
                 self.print_warn("No Podman machine is currently running")
                 self.print_info(
@@ -1788,14 +1784,14 @@ class FumitmWindows:
                 input=cert_content,
                 text=True,
                 capture_output=True,
-            )
+            check=False)
 
             if result.returncode == 0:
                 # Update CA trust
                 result = subprocess.run(
                     ["podman", "machine", "ssh", "sudo update-ca-trust"],
                     capture_output=True,
-                )
+                check=False)
                 if result.returncode == 0:
                     self.print_info("Podman certificate installed successfully")
                 else:
@@ -1832,14 +1828,14 @@ class FumitmWindows:
                 input=cert_content,
                 text=True,
                 capture_output=True,
-            )
+            check=False)
 
             if result.returncode == 0:
                 # Update CA certificates
                 result = subprocess.run(
                     ["rdctl", "shell", "sudo update-ca-certificates"],
                     capture_output=True,
-                )
+                check=False)
                 if result.returncode == 0:
                     self.print_info("Rancher certificate installed successfully")
                 else:
@@ -1860,7 +1856,7 @@ class FumitmWindows:
                 ["git", "config", "--global", "--get", "http.sslCAInfo"],
                 capture_output=True,
                 text=True,
-            )
+            check=False)
             current_ca_info = result.stdout.strip() if result.returncode == 0 else ""
         except Exception:
             current_ca_info = ""
@@ -1935,7 +1931,7 @@ class FumitmWindows:
                                     bundle_path,
                                 ],
                                 capture_output=True,
-                            )
+                            check=False)
                             if result.returncode == 0:
                                 self.print_info(
                                     f"Git reconfigured to use CA bundle: {bundle_path}"
@@ -1972,7 +1968,7 @@ class FumitmWindows:
                 result = subprocess.run(
                     ["git", "config", "--global", "http.sslCAInfo", bundle_path],
                     capture_output=True,
-                )
+                check=False)
                 if result.returncode == 0:
                     self.print_info(f"Git configured to use CA bundle: {bundle_path}")
                 else:
@@ -2017,7 +2013,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                         ["node", "-e", node_script],
                         capture_output=True,
                         text=True,
-                    )
+                    check=False)
 
                     if proc_result.returncode == 0:
                         result = "WORKING"
@@ -2052,7 +2048,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     result = "WORKING"
 
                     # Additional validation - check SSL context
-                    context = ssl.create_default_context()
+                    ssl.create_default_context()
                     self.print_debug(
                         f"Python SSL default verify paths: {ssl.get_default_verify_paths()}"
                     )
@@ -2098,12 +2094,12 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                             ["curl", "-v", "-s", "-o", "nul", test_url],
                             capture_output=True,
                             text=True,
-                        )
+                        check=False)
                     else:
                         curl_result = subprocess.run(
                             ["curl", "-s", "-o", "nul", test_url],
                             capture_output=True,
-                        )
+                        check=False)
 
                     if curl_result.returncode == 0:
                         result = "WORKING"
@@ -2198,7 +2194,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                         ["npm", "config", "get", "cafile"],
                         capture_output=True,
                         text=True,
-                    )
+                    check=False)
                     npm_cafile = result.stdout.strip() if result.returncode == 0 else ""
 
                     if npm_cafile and npm_cafile not in ["null", "undefined"]:
@@ -2324,18 +2320,17 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                         )
                         has_issues = True
 
-                if not python_configured:
-                    if not requests_ca_bundle and not ssl_cert_file:
-                        self.print_warn(
-                            "  ✗ Python does not trust system certificate by default"
-                        )
-                        self.print_warn(
-                            "  ✗ No Python certificate environment variables configured"
-                        )
-                        self.print_action(
-                            "    Run with --fix --tools python to configure certificate bundle"
-                        )
-                        has_issues = True
+                if not python_configured and not requests_ca_bundle and not ssl_cert_file:
+                    self.print_warn(
+                        "  ✗ Python does not trust system certificate by default"
+                    )
+                    self.print_warn(
+                        "  ✗ No Python certificate environment variables configured"
+                    )
+                    self.print_action(
+                        "    Run with --fix --tools python to configure certificate bundle"
+                    )
+                    has_issues = True
         else:
             self.print_info("  - Python not installed")
         return has_issues
@@ -2349,7 +2344,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     ["gcloud", "config", "get-value", "core/custom_ca_certs_file"],
                     capture_output=True,
                     text=True,
-                )
+                check=False)
                 gcloud_ca = result.stdout.strip() if result.returncode == 0 else ""
 
                 if gcloud_ca and os.path.exists(gcloud_ca):
@@ -2402,7 +2397,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                             "changeit",
                         ],
                         capture_output=True,
-                    )
+                    check=False)
                     if (
                         result.returncode == 0
                         and self.get_keytool_alias() in result.stdout.decode()
@@ -2456,7 +2451,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     ["podman", "machine", "list"],
                     capture_output=True,
                     text=True,
-                )
+                check=False)
                 if "Currently running" in result.stdout:
                     # Check if certificate exists in Podman VM
                     result = subprocess.run(
@@ -2467,7 +2462,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                             f"test -f /etc/pki/ca-trust/source/anchors/{self.get_container_cert_name()}",
                         ],
                         capture_output=True,
-                    )
+                    check=False)
                     if result.returncode == 0:
                         self.print_info(
                             f"  ✓ Podman VM has {self.get_provider_short_name()} certificate installed"
@@ -2491,7 +2486,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             try:
                 # Try to check if Rancher is running
                 result = subprocess.run(
-                    ["rdctl", "version"], capture_output=True, text=True
+                    ["rdctl", "version"], capture_output=True, text=True, check=False
                 )
                 if "rdctl" in result.stdout:
                     # Check if certificate exists in Rancher VM
@@ -2502,7 +2497,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                             f"test -f /usr/local/share/ca-certificates/{self.get_container_cert_name()}",
                         ],
                         capture_output=True,
-                    )
+                    check=False)
                     if result.returncode == 0:
                         self.print_info(
                             f"  ✓ Rancher Desktop VM has {self.get_provider_short_name()} certificate installed"
@@ -2531,7 +2526,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     ["git", "config", "--global", "--get", "http.sslCAInfo"],
                     capture_output=True,
                     text=True,
-                )
+                check=False)
                 git_ca_info = result.stdout.strip() if result.returncode == 0 else ""
 
                 if git_ca_info and os.path.exists(git_ca_info):
@@ -2606,11 +2601,11 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     temp_warp_cert,
                 ],
                 capture_output=True,
-            )
+            check=False)
             if result.returncode == 0:
                 self.print_info(f"  ✓ {short_name} certificate is valid")
             else:
-                raise Exception("OpenSSL validation failed")
+                raise RuntimeError("OpenSSL validation failed")
         except Exception as e:
             self.print_debug(
                 f"OpenSSL not available, trying PowerShell validation: {e}"
@@ -2640,7 +2635,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     ["powershell", "-Command", ps_command],
                     capture_output=True,
                     text=True,
-                )
+                check=False)
 
                 if result.returncode == 0:
                     self.print_info(f"  ✓ {short_name} certificate is valid")
@@ -2679,10 +2674,10 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             "SSL_CERT_FILE",
         ]:
             env_value = self.get_environment_variable(env_var)
-            if env_value and os.path.exists(env_value):
-                if self.certificate_exists_in_file(temp_warp_cert, env_value):
-                    cert_locations.append(f"    - {env_value} ({env_var})")
-                    cert_found = True
+            if (env_value and os.path.exists(env_value)
+                    and self.certificate_exists_in_file(temp_warp_cert, env_value)):
+                cert_locations.append(f"    - {env_value} ({env_var})")
+                cert_found = True
 
         if cert_found:
             self.print_info(f"  ✓ {short_name} certificate found in:")
@@ -2770,7 +2765,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                 )
                 if VERSION_INFO["dirty"]:
                     self.print_debug("Working directory has uncommitted changes")
-                self.print_debug(f"Script: Windows implementation")
+                self.print_debug("Script: Windows implementation")
                 self.print_debug(f"Running on: {platform.platform()}")
                 self.print_debug(f"Python version: {sys.version}")
                 self.print_debug(f"Home directory: {os.path.expanduser('~')}")
@@ -2826,9 +2821,8 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     print()
 
                 for tool_key, tool_info in self.tools_registry.items():
-                    if self.should_process_tool(tool_key):
-                        if tool_info.get("setup_func"):
-                            tool_info["setup_func"]()
+                    if self.should_process_tool(tool_key) and tool_info.get("setup_func"):
+                        tool_info["setup_func"]()
 
                 # Final message
                 print()

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,12 @@
+# Ruff runs with its default ruleset, minus rules that conflict with
+# deliberate patterns in this codebase:
+#
+# - BLE001 (blind-except): fumitm probes many external tools and environments
+#   on a best-effort basis and wraps those probes in broad `except Exception`
+#   handlers by design. The test suite's TestCodeQuality enforces this exact
+#   form over bare `except:`.
+# - S110 (try-except-pass): those same probes intentionally swallow failures
+#   and fall back to degraded behavior rather than aborting a run part-way.
+
+[lint]
+ignore = ["BLE001", "S110"]

--- a/test_suite/conftest.py
+++ b/test_suite/conftest.py
@@ -4,10 +4,9 @@ Pytest configuration for fumitm integration tests.
 This module provides shared fixtures and configuration for all tests.
 """
 import sys
-import os
 from pathlib import Path
+
 import pytest
-from unittest.mock import MagicMock, patch
 
 # Add parent directory to path so we can import fumitm.py
 sys.path.insert(0, str(Path(__file__).parent.parent))

--- a/test_suite/helpers.py
+++ b/test_suite/helpers.py
@@ -3,9 +3,9 @@ Test helpers and utilities for fumitm tests.
 
 This module provides helper classes and functions to simplify test setup and assertions.
 """
-from unittest.mock import MagicMock, patch, mock_open
-from pathlib import Path
 from contextlib import contextmanager
+from unittest.mock import MagicMock, mock_open, patch
+
 import mock_data
 
 

--- a/test_suite/test_fumitm_integration.py
+++ b/test_suite/test_fumitm_integration.py
@@ -6,17 +6,20 @@ by mocking external dependencies and testing realistic scenarios.
 """
 import os
 import subprocess
-import sys
 import urllib.error
-from unittest.mock import patch, MagicMock, call, mock_open
+from typing import ClassVar
+from unittest.mock import MagicMock, call, mock_open, patch
+
+import mock_data
 import pytest
 
 # Import test utilities
 from helpers import (
-    MockBuilder, mock_fumitm_environment, assert_subprocess_called_with,
-    assert_file_written, FumitmTestCase
+    FumitmTestCase,
+    MockBuilder,
+    assert_subprocess_called_with,
+    mock_fumitm_environment,
 )
-import mock_data
 
 # Import the fumitm module
 import fumitm
@@ -328,7 +331,6 @@ class TestBrewCacerts(FumitmTestCase):
     def test_setup_postinstall_success_but_cert_not_in_bundle(self):
         """setup_brew_cacerts warns when postinstall succeeds but cert not in bundle."""
         brew_prefix = '/opt/homebrew'
-        bundle_path = f'{brew_prefix}/etc/ca-certificates/cert.pem'
 
         mock_config = (MockBuilder()
             .with_certificate()
@@ -464,9 +466,7 @@ class TestJavaMultiInstallation(FumitmTestCase):
                 if path == '/usr/libexec/java_home':
                     return True
                 # Mock cacerts files exist for all Java homes
-                if 'lib/security/cacerts' in path:
-                    return True
-                return False
+                return 'lib/security/cacerts' in path
 
             mock_exists.side_effect = exists_side_effect
             mock_isfile.side_effect = lambda path: 'lib/security/cacerts' in path
@@ -632,16 +632,12 @@ class TestJavaMultiInstallation(FumitmTestCase):
         def isfile_side_effect(path):
             if path == sdkman_java_dir:
                 return False
-            if 'lib/security/cacerts' in path:
-                return True
-            return False
+            return 'lib/security/cacerts' in path
 
         def isdir_side_effect(path):
             if path == sdkman_java_dir:
                 return True
-            if any(v in path for v in sdkman_versions):
-                return True
-            return False
+            return bool(any(v in path for v in sdkman_versions))
 
         with patch('platform.system', return_value='Darwin'), \
              patch.dict(os.environ, {'JAVA_HOME': '', 'SDKMAN_DIR': ''}, clear=False), \
@@ -685,7 +681,7 @@ class TestJavaMultiInstallation(FumitmTestCase):
 
         current_path = os.path.join(sdkman_java_dir, 'current')
         assert current_path not in java_homes, \
-            f"'current' symlink should not appear as a separate entry in java_homes"
+            "'current' symlink should not appear as a separate entry in java_homes"
 
     def test_find_all_java_homes_sdkman_absent(self):
         """find_all_java_homes does not fail when ~/.sdkman/candidates/java does not exist."""
@@ -768,14 +764,10 @@ class TestJavaMultiInstallation(FumitmTestCase):
                 return True
             if path == default_sdkman_java_dir:
                 return False
-            if '21.0.2-tem' in path:
-                return True
-            return False
+            return '21.0.2-tem' in path
 
         def isfile_side_effect(path):
-            if 'lib/security/cacerts' in path and '21.0.2-tem' in path:
-                return True
-            return False
+            return bool('lib/security/cacerts' in path and '21.0.2-tem' in path)
 
         env = {'SDKMAN_DIR': custom_sdkman_root, 'JAVA_HOME': ''}
         with patch('platform.system', return_value='Darwin'), \
@@ -803,12 +795,12 @@ class TestCLIAndWorkflow(FumitmTestCase):
     """Tests for CLI argument parsing and complete workflows."""
     
     # Default kwargs for new headless/MDM flags, used by CLI constructor tests
-    _DEFAULT_NEW_KWARGS = dict(
-        no_color=False, headless=False, skip_update_check=False,
-        log_file=None, log_dir=None, json_log_file=None, json_log_dir=None,
-        run_as_user=None, with_aikido=False, no_aikido=False,
-        aikido_cert_file=None,
-    )
+    _DEFAULT_NEW_KWARGS: ClassVar[dict] = {
+        'no_color': False, 'headless': False, 'skip_update_check': False,
+        'log_file': None, 'log_dir': None, 'json_log_file': None, 'json_log_dir': None,
+        'run_as_user': None, 'with_aikido': False, 'no_aikido': False,
+        'aikido_cert_file': None,
+    }
 
     @patch('fumitm.sys.argv', ['fumitm.py', '--fix'])
     def test_cli_fix_mode(self):
@@ -973,15 +965,15 @@ class TestErrorScenarios(FumitmTestCase):
             .with_tools('openssl')
             .build())
         
-        with mock_fumitm_environment(mock_config):
-            with patch('fumitm.shutil.copy') as mock_copy:
-                mock_copy.side_effect = PermissionError(mock_data.PERMISSION_DENIED_ERROR)
-                
-                instance = self.create_fumitm_instance(mode='install')
-                # The download_certificate method doesn't catch PermissionError
-                # so we expect it to raise
-                with pytest.raises(PermissionError):
-                    instance.download_certificate()
+        with mock_fumitm_environment(mock_config), \
+                patch('fumitm.shutil.copy') as mock_copy:
+            mock_copy.side_effect = PermissionError(mock_data.PERMISSION_DENIED_ERROR)
+
+            instance = self.create_fumitm_instance(mode='install')
+            # The download_certificate method doesn't catch PermissionError
+            # so we expect it to raise
+            with pytest.raises(PermissionError):
+                instance.download_certificate()
     
     def test_malformed_certificate_handling(self):
         """Test handling of malformed certificates from warp-cli."""
@@ -1080,7 +1072,7 @@ class TestPlatformSpecific(FumitmTestCase):
     def test_platform_specific_paths(self, platform, expected_path):
         """Test that platform-specific paths are used correctly."""
         with patch('platform.system', return_value=platform):
-            instance = fumitm.FumitmPython(mode='status')
+            fumitm.FumitmPython(mode='status')
 
             # Check that instance is aware of platform
             # This would need actual implementation testing
@@ -1282,10 +1274,10 @@ class TestBundleCreation(FumitmTestCase):
             instance = fumitm.FumitmPython(mode='install')
 
             # Test True case (system certs exist)
-            with patch('os.path.exists', side_effect=lambda p: p == "/etc/ssl/cert.pem"):
-                with patch('shutil.copy'):
-                    result = instance.create_bundle_with_system_certs(str(target_bundle))
-                    assert result is True
+            with patch('os.path.exists', side_effect=lambda p: p == "/etc/ssl/cert.pem"), \
+                    patch('shutil.copy'):
+                result = instance.create_bundle_with_system_certs(str(target_bundle))
+                assert result is True
 
             # Test False case (no system certs)
             with patch('os.path.exists', return_value=False):
@@ -1508,14 +1500,14 @@ class TestCodeQuality:
                 continue
 
             # Check for unsafe patterns
-            if re.search(r"with\s+open\s*\([^)]*['\"]a['\"]\s*\)", line, re.IGNORECASE):
-                if 'bundle' in line.lower() or 'cert' in line.lower() or 'ca' in line.lower():
-                    unsafe_lines.append(f"Line {i}: {line.strip()}")
+            if (re.search(r"with\s+open\s*\([^)]*['\"]a['\"]\s*\)", line, re.IGNORECASE)
+                    and ('bundle' in line.lower() or 'cert' in line.lower() or 'ca' in line.lower())):
+                unsafe_lines.append(f"Line {i}: {line.strip()}")
 
         assert not unsafe_lines, (
-            f"Found unsafe certificate append patterns in fumitm_windows.py:\n"
+            "Found unsafe certificate append patterns in fumitm_windows.py:\n"
             + "\n".join(unsafe_lines) + "\n\n"
-            f"Use self.append_certificate_if_missing(cert_path, target_path) instead"
+            "Use self.append_certificate_if_missing(cert_path, target_path) instead"
         )
 
     def test_no_unused_globals_in_fumitm(self):
@@ -1660,9 +1652,9 @@ class TestCodeQuality:
                 bare_excepts.append(f"Line {i}: {line.strip()}")
 
         assert not bare_excepts, (
-            f"Found bare 'except:' clauses in fumitm.py:\n"
+            "Found bare 'except:' clauses in fumitm.py:\n"
             + "\n".join(bare_excepts) + "\n\n"
-            f"Replace with 'except Exception:' or a more specific exception type."
+            "Replace with 'except Exception:' or a more specific exception type."
         )
 
     def test_no_raw_cert_comparisons_in_fumitm(self):
@@ -1705,7 +1697,7 @@ class TestCodeQuality:
                     violations.append(f"Line {i}: {line.strip()} ({description})")
 
         assert not violations, (
-            f"Found raw certificate comparisons in fumitm.py:\n"
+            "Found raw certificate comparisons in fumitm.py:\n"
             + "\n".join(violations) + "\n\n"
             "Setup functions must use self.certificate_exists_in_file(CERT_PATH, target)\n"
             "instead of raw 'cert_content in file_content' comparisons.\n"
@@ -1751,7 +1743,7 @@ class TestCodeQuality:
                 violations.append(f"Line {i}: {stripped}")
 
         assert not violations, (
-            f"Found raw os.makedirs() calls outside _safe_makedirs in fumitm.py:\n"
+            "Found raw os.makedirs() calls outside _safe_makedirs in fumitm.py:\n"
             + "\n".join(violations) + "\n\n"
             "Use self._safe_makedirs(path) instead to ensure correct ownership under sudo."
         )
@@ -1830,7 +1822,6 @@ class TestOwnershipProtection(FumitmTestCase):
 
     def test_home_correction_under_sudo_linux(self):
         """Verify HOME is corrected when sudo sets it to /root."""
-        import pwd
 
         mock_pw = MagicMock()
         mock_pw.pw_dir = '/home/realuser'
@@ -1839,7 +1830,7 @@ class TestOwnershipProtection(FumitmTestCase):
              patch.dict(os.environ, {'SUDO_USER': 'realuser', 'HOME': '/root'}), \
              patch('pwd.getpwnam', return_value=mock_pw), \
              patch('platform.system', return_value='Linux'):
-            instance = fumitm.FumitmPython(mode='status', provider='warp')
+            fumitm.FumitmPython(mode='status', provider='warp')
             assert os.environ['HOME'] == '/home/realuser'
 
     def test_check_ownership_sanity_detects_root_files(self, tmp_path):
@@ -2009,7 +2000,7 @@ class TestPerformance(FumitmTestCase):
 
         with patch('subprocess.run') as mock_subprocess:
             # Check if certificate exists in bundle
-            result = instance.certificate_likely_exists_in_file(
+            instance.certificate_likely_exists_in_file(
                 str(cert_file), str(bundle_file)
             )
 
@@ -2030,17 +2021,17 @@ class TestPerformance(FumitmTestCase):
             instance = fumitm.FumitmPython(mode='install')
 
         # Mock the CERT_PATH to our test file
-        with patch.object(fumitm, 'CERT_PATH', str(cert_file)):
-            with patch('subprocess.run') as mock_subprocess:
+        with patch.object(fumitm, 'CERT_PATH', str(cert_file)), \
+                patch('subprocess.run') as mock_subprocess:
                 mock_subprocess.return_value = MagicMock(
                     returncode=0,
                     stdout="SHA256 Fingerprint=AA:BB:CC:DD"
                 )
 
                 # Call get_cert_fingerprint multiple times
-                fp1 = instance.get_cert_fingerprint(str(cert_file))
-                fp2 = instance.get_cert_fingerprint(str(cert_file))
-                fp3 = instance.get_cert_fingerprint(str(cert_file))
+                instance.get_cert_fingerprint(str(cert_file))
+                instance.get_cert_fingerprint(str(cert_file))
+                instance.get_cert_fingerprint(str(cert_file))
 
                 # Should only call subprocess once (cached after first call)
                 # Note: current implementation caches only for CERT_PATH
@@ -2570,7 +2561,6 @@ class TestToolResultAccuracy(FumitmTestCase):
 
             # keytool -list says not installed, keytool -import fails (permission denied)
             def run_side_effect(*args, **kwargs):
-                cmd = args[0]
                 result = MagicMock()
                 result.returncode = 1
                 result.stdout = b'Permission denied'
@@ -2701,9 +2691,7 @@ class TestToolResultAccuracy(FumitmTestCase):
         def isfile_side_effect(path):
             if path == modern_path:
                 return False  # it's a directory, not a file
-            if path == legacy_path:
-                return True
-            return False
+            return path == legacy_path
 
         with patch('os.path.isfile', side_effect=isfile_side_effect):
             result = instance.find_java_cacerts(java_home)
@@ -3286,8 +3274,6 @@ class TestBareReturnsFixed(FumitmTestCase):
     def test_brew_cacerts_status_mode_returns_skipped(self):
         """setup_brew_cacerts returns skipped in dry-run mode when bundle missing."""
         instance = self.create_fumitm_instance(mode='status')
-        brew_prefix = instance._get_brew_prefix()
-        bundle_path = os.path.join(brew_prefix, 'etc', 'ca-certificates', 'cert.pem')
         with patch.object(instance, 'command_exists', return_value=True), \
              patch('subprocess.run') as mock_run, \
              patch('os.path.exists', return_value=False):
@@ -3366,9 +3352,7 @@ class TestBareReturnsFixed(FumitmTestCase):
         def exists_side_effect(path):
             if path == python_bundle:
                 return True
-            if path == shell_config:
-                return True
-            return False
+            return path == shell_config
 
         shell_content = f'export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="{python_bundle}"\n'
         mock_open_obj = mock_open(read_data=shell_content)
@@ -3410,9 +3394,7 @@ class TestBareReturnsFixed(FumitmTestCase):
         def exists_side_effect(path):
             if path == python_bundle:
                 return True
-            if path == shell_config:
-                return True
-            return False
+            return path == shell_config
 
         stale = 'export CLOUDSDK_CORE_CUSTOM_CA_CERTS_FILE="/wrong/path.pem"\n'
         mock_open_obj = mock_open(read_data=stale)

--- a/test_suite/test_fumitm_windows.py
+++ b/test_suite/test_fumitm_windows.py
@@ -4,19 +4,19 @@ Integration tests for fumitm_windows.py
 These tests verify the Windows port's functionality, particularly the
 certificate appending logic and newline handling fix for issue #13.
 """
-import sys
 import re
-import pytest
+import sys
 from unittest.mock import patch
+
+import pytest
 
 # Skip entire module on non-Windows platforms
 if sys.platform != 'win32':
     pytest.skip("Windows-only tests", allow_module_level=True)
 
 # Import test utilities
-from helpers import import_fumitm_windows
 import mock_data
-
+from helpers import import_fumitm_windows
 
 # Import the Windows module using our helper
 fumitm_windows = import_fumitm_windows()

--- a/test_suite/test_headless_mdm.py
+++ b/test_suite/test_headless_mdm.py
@@ -7,14 +7,14 @@ accuracy, exit codes, and orchestrator environment simulations.
 """
 import json
 import os
-import sys
 import tempfile
 from datetime import datetime
-from unittest.mock import patch, MagicMock
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
-
 from helpers import FumitmTestCase
+
 import fumitm
 from fumitm import NonInteractiveError, ToolResult
 
@@ -163,7 +163,7 @@ class TestLogFile(FumitmTestCase):
             instance.print_info("test message")
             instance._close_log_files()
 
-            content = open(path).read()
+            content = Path(path).read_text()
             assert '[INFO] test message' in content
             assert '\033[' not in content
         finally:
@@ -180,7 +180,7 @@ class TestLogFile(FumitmTestCase):
             instance.print_info("hello")
             instance._close_log_files()
 
-            line = open(path).readline()
+            line = Path(path).read_text().splitlines()[0]
             # Format: 2026-03-03T14:30:00 [INFO] hello
             assert line[4] == '-' and line[10] == 'T'
         finally:
@@ -201,7 +201,7 @@ class TestLogFile(FumitmTestCase):
             # Symlink points to a real file with content
             target = os.path.join(tmpdir, os.readlink(symlink))
             assert os.path.isfile(target)
-            content = open(target).read()
+            content = Path(target).read_text()
             assert 'run one' in content
 
     def test_log_dir_symlink_updates_on_second_run(self):
@@ -211,8 +211,8 @@ class TestLogFile(FumitmTestCase):
                 no_color=True, log_dir=tmpdir
             )
             with patch('fumitm.datetime') as mock_dt:
-                mock_dt.now.return_value.strftime.return_value = '20260101-000001'
-                mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+                mock_dt.now.return_value.astimezone.return_value.strftime.return_value = '20260101-000001'
+                mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)  # noqa: DTZ001 (mock passthrough)
                 inst1._open_log_files()
             inst1.print_info("first")
             inst1._close_log_files()
@@ -224,8 +224,8 @@ class TestLogFile(FumitmTestCase):
                 no_color=True, log_dir=tmpdir
             )
             with patch('fumitm.datetime') as mock_dt:
-                mock_dt.now.return_value.strftime.return_value = '20260101-000002'
-                mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+                mock_dt.now.return_value.astimezone.return_value.strftime.return_value = '20260101-000002'
+                mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)  # noqa: DTZ001 (mock passthrough)
                 inst2._open_log_files()
             inst2.print_info("second")
             inst2._close_log_files()
@@ -235,7 +235,7 @@ class TestLogFile(FumitmTestCase):
             assert first_target != second_target
             assert os.path.isfile(os.path.join(tmpdir, first_target))
             assert os.path.isfile(os.path.join(tmpdir, second_target))
-            assert 'second' in open(os.path.join(tmpdir, second_target)).read()
+            assert 'second' in Path(tmpdir, second_target).read_text()
 
 
     def test_unwritable_log_path_warns_continues(self, capsys):
@@ -296,7 +296,7 @@ class TestJsonLogFile(FumitmTestCase):
             instance.print_error("bad thing")
             instance._close_log_files()
 
-            lines = open(path).readlines()
+            lines = Path(path).read_text().splitlines()
             assert len(lines) == 2
             for line in lines:
                 event = json.loads(line)
@@ -326,7 +326,7 @@ class TestJsonLogFile(FumitmTestCase):
             instance.print_error("error msg")
             instance._close_log_files()
 
-            lines = [json.loads(l) for l in open(path)]
+            lines = [json.loads(l) for l in Path(path).read_text().splitlines()]
             assert lines[0]['level'] == 'info'
             assert lines[1]['level'] == 'warn'
             assert lines[2]['level'] == 'error'
@@ -345,7 +345,7 @@ class TestJsonLogFile(FumitmTestCase):
             symlink = os.path.join(tmpdir, 'fumitm-latest.jsonl')
             assert os.path.islink(symlink)
             target = os.path.join(tmpdir, os.readlink(symlink))
-            event = json.loads(open(target).readline())
+            event = json.loads(Path(target).read_text().splitlines()[0])
             assert 'hello json' in event['message']
 
     def test_json_log_no_ansi(self):
@@ -359,7 +359,7 @@ class TestJsonLogFile(FumitmTestCase):
             instance.print_info("clean")
             instance._close_log_files()
 
-            event = json.loads(open(path).readline())
+            event = json.loads(Path(path).read_text().splitlines()[0])
             assert '\033[' not in event['message']
         finally:
             os.unlink(path)
@@ -382,7 +382,7 @@ class TestJsonLogFile(FumitmTestCase):
             instance._run_setup('test-tool', failing_setup)
             instance._close_log_files()
 
-            events = [json.loads(line) for line in open(path)]
+            events = [json.loads(line) for line in Path(path).read_text().splitlines()]
             error_events = [e for e in events if e['level'] == 'error']
             assert len(error_events) >= 1
             assert error_events[0]['phase'] == 'tool'
@@ -587,10 +587,10 @@ class TestRunAsUser(FumitmTestCase):
 
     def test_run_as_user_requires_root(self):
         """--run-as-user from non-root must fail at argparse level."""
-        with patch('fumitm.sys.argv', ['fumitm.py', '--run-as-user', 'bob']):
-            with patch('os.getuid', return_value=1000):
-                with pytest.raises(SystemExit):
-                    fumitm.main()
+        with patch('fumitm.sys.argv', ['fumitm.py', '--run-as-user', 'bob']), \
+                patch('os.getuid', return_value=1000), \
+                pytest.raises(SystemExit):
+            fumitm.main()
 
     def test_apply_target_user_sets_home(self):
         """_apply_target_user sets HOME to target user's home dir."""
@@ -681,9 +681,9 @@ class TestRunAsUser(FumitmTestCase):
     def test_apply_target_user_upn_both_fail(self):
         """UPN fallback exits when both full and short name fail."""
         instance = self.create_fumitm_instance()
-        with patch('fumitm.pwd.getpwnam', side_effect=KeyError('nope')):
-            with pytest.raises(SystemExit):
-                instance._apply_target_user('ghost@domain.com')
+        with patch('fumitm.pwd.getpwnam', side_effect=KeyError('nope')), \
+                pytest.raises(SystemExit):
+            instance._apply_target_user('ghost@domain.com')
 
     def test_apply_target_user_augments_path_arm64(self):
         """_apply_target_user prepends /opt/homebrew/bin on Apple Silicon."""

--- a/test_suite/test_netskope_provider.py
+++ b/test_suite/test_netskope_provider.py
@@ -6,12 +6,12 @@ and verifies that provider-specific values flow through to bundle paths,
 keytool aliases, and container certificate filenames.
 """
 import os
-import sys
-from unittest.mock import patch, MagicMock, mock_open
-import pytest
+from typing import ClassVar
+from unittest.mock import MagicMock, mock_open, patch
 
-from helpers import FumitmTestCase, MockBuilder
 import mock_data
+import pytest
+from helpers import FumitmTestCase
 
 import fumitm
 
@@ -279,12 +279,12 @@ class TestProviderCLI(FumitmTestCase):
     """Tests for --provider CLI argument."""
 
     # Default kwargs for new headless/MDM flags
-    _DEFAULT_NEW_KWARGS = dict(
-        no_color=False, headless=False, skip_update_check=False,
-        log_file=None, log_dir=None, json_log_file=None, json_log_dir=None,
-        run_as_user=None, with_aikido=False, no_aikido=False,
-        aikido_cert_file=None,
-    )
+    _DEFAULT_NEW_KWARGS: ClassVar[dict] = {
+        'no_color': False, 'headless': False, 'skip_update_check': False,
+        'log_file': None, 'log_dir': None, 'json_log_file': None, 'json_log_dir': None,
+        'run_as_user': None, 'with_aikido': False, 'no_aikido': False,
+        'aikido_cert_file': None,
+    }
 
     @patch('fumitm.sys.argv', ['fumitm.py', '--provider', 'netskope'])
     def test_cli_provider_netskope(self):

--- a/test_suite/test_suspicious_bundles.py
+++ b/test_suite/test_suspicious_bundles.py
@@ -4,11 +4,11 @@ Tests for detecting suspiciously small CA bundles.
 These tests focus on the helper heuristics introduced to catch cases where
 users accidentally point full-bundle env vars at a single WARP CA cert.
 """
-import pytest
 
-from helpers import MockBuilder, mock_fumitm_environment, FumitmTestCase
-from unittest.mock import patch, ANY
+from unittest.mock import ANY, patch
+
 import mock_data
+from helpers import FumitmTestCase, MockBuilder, mock_fumitm_environment
 
 
 class TestSuspiciousBundles(FumitmTestCase):
@@ -42,7 +42,7 @@ class TestSuspiciousBundles(FumitmTestCase):
 
         with mock_fumitm_environment(mock_config):
             instance = self.create_fumitm_instance()
-            suspicious, reason = instance.is_suspicious_full_bundle(bundle_path, None)
+            suspicious, _reason = instance.is_suspicious_full_bundle(bundle_path, None)
             assert suspicious is False
 
     def test_npm_repoint_on_suspicious_existing(self):


### PR DESCRIPTION
Fixes all 408 findings from ruff's default ruleset (ruff 0.16) and adds a `ruff.toml` so the policy is pinned in-repo.

## Changes

- **`ruff.toml`**: default ruleset with two documented ignores — `BLE001` (the broad `except Exception:` probe pattern this repo's own `TestCodeQuality` enforces over bare `except:`) and `S110` (intentional best-effort swallowing in tool probes).
- **PLW1510 (147 sites)**: explicit `check=False` on every `subprocess.run` call. Behavior is unchanged — all call sites inspect `returncode` themselves.
- **Autofixes**: unused imports, placeholder-less f-strings, import sorting, unused variables.
- **Manual fixes**: collapsed nested `if`/`with` statements; log timestamps now use timezone-aware local time (`datetime.now(timezone.utc).astimezone()`, mocked test chains updated to match); `ClassVar` annotations on mutable class attributes; `RuntimeError` instead of vanilla `Exception` in `fumitm_windows.py`; `chmod +x fumitm_windows.py` to match its shebang.
- **Justified noqa (6 sites)**: log file handles that deliberately outlive their method (closed in `_close_log_files`) and naive-datetime mock passthroughs in tests.

## Verification

- `uvx ruff check .` — clean
- Full test suite: 376 passed, 1 skipped (pre-existing Windows-only guard)
- `./fumitm.py --tools curl` smoke-tested on a live Netskope machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWcdVUizPnPEos86nniVhx