### PR TITLE
Activate the invoking shell explicitly after --fix (issue #100, Option A)

### DIFF
--- a/README-automation.md
+++ b/README-automation.md
@@ -55,7 +55,13 @@ Fields:
 - `exit_code`: the exit code that will be returned.
 - `shell_reload_required`: `true` when shell configuration was modified. Already-running shells keep their old environment until they source the env file or a new shell is opened; fumitm cannot modify the environment of the process that invoked it.
 - `shell_reload_command`: the command for the *end user's own shell*, `$HOME`-relative, or `null` when no reload is needed or the shell has no safe one-liner. Do not use this from an automation wrapper: under `--run-as-user` the wrapper's `$HOME` (e.g. `/var/root`) is not the target user's.
-- `shell_env_file`: absolute path of the generated env file, already resolved against the target user's home, or `null` when none exists. Reported whenever the file exists — including converged reruns where `shell_reload_required` is `false` — because a freshly started wrapper process has not inherited the environment and still needs to source this path before launching dependent children.
+- `shell_env_file`: absolute path of the generated env file, already resolved against the target user's home, or `null` when none exists. Reported whenever the file exists — including converged reruns where `shell_reload_required` is `false` — because a freshly started wrapper process has not inherited the environment. **Trust boundary:** the file lives in the target user's home and is owned and writable by that user. A privileged (root) wrapper must never source it or otherwise evaluate it as shell code — that executes user-controlled content as root, and the file can be replaced between fumitm returning and the wrapper reading it. When a dependent child needs the environment, drop privileges first so the sourcing happens as the target user:
+
+  ```bash
+  sudo -u "$target_user" sh -c '. "$env_file" && exec dependent-command'
+  ```
+
+  Wrappers already running as the target user (Ansible `become_user`, direct `sudo -u` execs) may source the path directly — it is their own file.
 
 Ansible `changed_when` must use `!= false` to treat `null` (unknown) as changed (conservative):
 

--- a/README-automation.md
+++ b/README-automation.md
@@ -46,13 +46,15 @@ Exit codes 2 and 3 are deliberately separate: exit 2 is always a caller/config p
 In install mode (`--fix`), fumitm prints a `FUMITM_RESULT:` line to stdout after the install loop:
 
 ```
-FUMITM_RESULT: {"changes_made":true,"configured":2,"completed":5,"already_ok":0,"skipped":3,"failed":1,"exit_code":3}
+FUMITM_RESULT: {"changes_made":true,"configured":2,"completed":5,"already_ok":0,"skipped":3,"failed":1,"exit_code":3,"shell_reload_required":true,"shell_reload_command":". \"$HOME/.config/fumitm/env.sh\""}
 ```
 
 Fields:
 - `changes_made`: `true` if any tool returned `configured`; `false` if no changes were made (all `already_ok`, all `skipped`, or no results); `null` if legacy `completed` statuses make change state unknown.
 - `configured` / `completed` / `already_ok` / `skipped` / `failed`: per-status counts.
 - `exit_code`: the exit code that will be returned.
+- `shell_reload_required`: `true` when shell configuration was modified. Already-running shells keep their old environment until they source the env file or a new shell is opened; fumitm cannot modify the environment of the process that invoked it.
+- `shell_reload_command`: the exact command a user (or wrapper script needing the new environment for its own children) can source, or `null` when no reload is needed or the shell has no safe one-liner.
 
 Ansible `changed_when` must use `!= false` to treat `null` (unknown) as changed (conservative):
 

--- a/README-automation.md
+++ b/README-automation.md
@@ -55,10 +55,10 @@ Fields:
 - `exit_code`: the exit code that will be returned.
 - `shell_reload_required`: `true` when shell configuration was modified. Already-running shells keep their old environment until they source the env file or a new shell is opened; fumitm cannot modify the environment of the process that invoked it.
 - `shell_reload_command`: the command for the *end user's own shell*, `$HOME`-relative, or `null` when no reload is needed or the shell has no safe one-liner. Do not use this from an automation wrapper: under `--run-as-user` the wrapper's `$HOME` (e.g. `/var/root`) is not the target user's.
-- `shell_env_file`: absolute path of the generated env file, already resolved against the target user's home, or `null` when none exists. Reported whenever the file exists — including converged reruns where `shell_reload_required` is `false` — because a freshly started wrapper process has not inherited the environment. **Trust boundary:** the file lives in the target user's home and is owned and writable by that user. A privileged (root) wrapper must never source it or otherwise evaluate it as shell code — that executes user-controlled content as root, and the file can be replaced between fumitm returning and the wrapper reading it. When a dependent child needs the environment, drop privileges first so the sourcing happens as the target user:
+- `shell_env_file`: absolute path of the generated env file, already resolved against the target user's home, or `null` when none exists. Reported whenever the file exists — including converged reruns where `shell_reload_required` is `false` — because a freshly started wrapper process has not inherited the environment. **Trust boundary:** the file lives in the target user's home and is owned and writable by that user. A privileged (root) wrapper must never source it or otherwise evaluate it as shell code — that executes user-controlled content as root, and the file can be replaced between fumitm returning and the wrapper reading it. When a dependent child needs the environment, drop privileges first so the sourcing happens as the target user. The path is passed as a positional argument — the wrapper's `$env_file` variable is not visible inside the single-quoted `sh -c` body:
 
   ```bash
-  sudo -u "$target_user" sh -c '. "$env_file" && exec dependent-command'
+  sudo -u "$target_user" sh -c '. "$1" && exec dependent-command' sh "$env_file"
   ```
 
   Wrappers already running as the target user (Ansible `become_user`, direct `sudo -u` execs) may source the path directly — it is their own file.

--- a/README-automation.md
+++ b/README-automation.md
@@ -46,7 +46,7 @@ Exit codes 2 and 3 are deliberately separate: exit 2 is always a caller/config p
 In install mode (`--fix`), fumitm prints a `FUMITM_RESULT:` line to stdout after the install loop:
 
 ```
-FUMITM_RESULT: {"changes_made":true,"configured":2,"completed":5,"already_ok":0,"skipped":3,"failed":1,"exit_code":3,"shell_reload_required":true,"shell_reload_command":". \"$HOME/.config/fumitm/env.sh\""}
+FUMITM_RESULT: {"changes_made":true,"configured":2,"completed":5,"already_ok":0,"skipped":3,"failed":1,"exit_code":3,"shell_reload_required":true,"shell_reload_command":". \"$HOME/.config/fumitm/env.sh\"","shell_env_file":"/Users/alice/.config/fumitm/env.sh"}
 ```
 
 Fields:
@@ -54,7 +54,8 @@ Fields:
 - `configured` / `completed` / `already_ok` / `skipped` / `failed`: per-status counts.
 - `exit_code`: the exit code that will be returned.
 - `shell_reload_required`: `true` when shell configuration was modified. Already-running shells keep their old environment until they source the env file or a new shell is opened; fumitm cannot modify the environment of the process that invoked it.
-- `shell_reload_command`: the exact command a user (or wrapper script needing the new environment for its own children) can source, or `null` when no reload is needed or the shell has no safe one-liner.
+- `shell_reload_command`: the command for the *end user's own shell*, `$HOME`-relative, or `null` when no reload is needed or the shell has no safe one-liner. Do not use this from an automation wrapper: under `--run-as-user` the wrapper's `$HOME` (e.g. `/var/root`) is not the target user's.
+- `shell_env_file`: absolute path of the generated env file, already resolved against the target user's home. A wrapper script that needs the new environment for its own child processes should source this path.
 
 Ansible `changed_when` must use `!= false` to treat `null` (unknown) as changed (conservative):
 

--- a/README-automation.md
+++ b/README-automation.md
@@ -55,7 +55,7 @@ Fields:
 - `exit_code`: the exit code that will be returned.
 - `shell_reload_required`: `true` when shell configuration was modified. Already-running shells keep their old environment until they source the env file or a new shell is opened; fumitm cannot modify the environment of the process that invoked it.
 - `shell_reload_command`: the command for the *end user's own shell*, `$HOME`-relative, or `null` when no reload is needed or the shell has no safe one-liner. Do not use this from an automation wrapper: under `--run-as-user` the wrapper's `$HOME` (e.g. `/var/root`) is not the target user's.
-- `shell_env_file`: absolute path of the generated env file, already resolved against the target user's home. A wrapper script that needs the new environment for its own child processes should source this path.
+- `shell_env_file`: absolute path of the generated env file, already resolved against the target user's home, or `null` when none exists. Reported whenever the file exists — including converged reruns where `shell_reload_required` is `false` — because a freshly started wrapper process has not inherited the environment and still needs to source this path before launching dependent children.
 
 Ansible `changed_when` must use `!= false` to treat `null` (unknown) as changed (conservative):
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ Script to automatically verify and fix MITM TLS distrust issues commonly afflict
 
 ```bash
 # Fix everything in one shot (no prompts, no download needed)
-python3 <(curl -LsSf https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py) --fix --yes
-source ~/.zshrc  # or ~/.bashrc
+python3 <(curl -LsSf https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py) --fix --yes &&
+  . "$HOME/.config/fumitm/env.sh"
 
 # With sudo (needed for Java keystores, DBeaver, and other system-level fixes)
-sudo python3 <(curl -LsSf https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py) --fix --yes --run-as-user $USER
-source ~/.zshrc  # or ~/.bashrc
+sudo python3 <(curl -LsSf https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py) --fix --yes --run-as-user $USER &&
+  . "$HOME/.config/fumitm/env.sh"
 ```
+
+The trailing `. "$HOME/.config/fumitm/env.sh"` activates the new TLS environment in your current terminal. A child process cannot modify its parent shell, so without it the fixes only apply to newly opened shells.
 
 For more control, download the script first:
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,17 @@ Script to automatically verify and fix MITM TLS distrust issues commonly afflict
 
 ```bash
 # Fix everything in one shot (no prompts, no download needed)
-python3 <(curl -LsSf https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py) --fix --yes
+_fumitm_status=0; python3 <(curl -LsSf https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py) --fix --yes || _fumitm_status=$?
 [ -r "$HOME/.config/fumitm/env.sh" ] && . "$HOME/.config/fumitm/env.sh"
+(exit $_fumitm_status)
 
 # With sudo (needed for Java keystores, DBeaver, and other system-level fixes)
-sudo python3 <(curl -LsSf https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py) --fix --yes --run-as-user $USER
+_fumitm_status=0; sudo python3 <(curl -LsSf https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py) --fix --yes --run-as-user $USER || _fumitm_status=$?
 [ -r "$HOME/.config/fumitm/env.sh" ] && . "$HOME/.config/fumitm/env.sh"
+(exit $_fumitm_status)
 ```
 
-The second line activates the new TLS environment in your current terminal. A child process cannot modify its parent shell, so without it the fixes only apply to newly opened shells. It is a separate command rather than an `&&` chain so that a partial-success run (exit code 3 — some tools fixed, some not) still activates what was configured; it sources the file whenever it exists, which is exactly what any new shell would do.
+The middle line activates the new TLS environment in your current terminal — a child process cannot modify its parent shell, so without it the fixes only apply to newly opened shells. It runs even after a partial-success run (exit code 3 — some tools fixed, some not), sourcing the env file whenever it exists, which is exactly what any new shell would do. The surrounding two lines keep fumitm's own exit status as the block's final `$?`: activation neither hides a failure nor manufactures one, and under `set -e` the activation line still runs before a failing status stops the script.
 
 For more control, download the script first:
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ Script to automatically verify and fix MITM TLS distrust issues commonly afflict
 # Fix everything in one shot (no prompts, no download needed)
 _fumitm_status=0; python3 <(curl -LsSf https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py) --fix --yes || _fumitm_status=$?
 [ -r "$HOME/.config/fumitm/env.sh" ] && . "$HOME/.config/fumitm/env.sh"
-(exit $_fumitm_status)
+case $- in *i*) ;; *) (exit "$_fumitm_status");; esac
 
 # With sudo (needed for Java keystores, DBeaver, and other system-level fixes)
 _fumitm_status=0; sudo python3 <(curl -LsSf https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py) --fix --yes --run-as-user $USER || _fumitm_status=$?
 [ -r "$HOME/.config/fumitm/env.sh" ] && . "$HOME/.config/fumitm/env.sh"
-(exit $_fumitm_status)
+case $- in *i*) ;; *) (exit "$_fumitm_status");; esac
 ```
 
-The middle line activates the new TLS environment in your current terminal — a child process cannot modify its parent shell, so without it the fixes only apply to newly opened shells. It runs even after a partial-success run (exit code 3 — some tools fixed, some not), sourcing the env file whenever it exists, which is exactly what any new shell would do. The surrounding two lines keep fumitm's own exit status as the block's final `$?`: activation neither hides a failure nor manufactures one, and under `set -e` the activation line still runs before a failing status stops the script.
+The middle line activates the new TLS environment in your current terminal — a child process cannot modify its parent shell, so without it the fixes only apply to newly opened shells. It runs even after a partial-success run (exit code 3 — some tools fixed, some not), sourcing the env file whenever it exists, which is exactly what any new shell would do. The final line restores fumitm's exit status in scripts only: a wrapper script sees fumitm's real status as `$?`, and under `set -e` it stops there — after activation has run. Interactive shells are deliberately excluded (the `case $- in *i*)` guard): restoring a failure status into a terminal that has `set -e` enabled would terminate the session instead of returning to the prompt, so when pasted into a terminal the block always ends with status 0 and the outcome is read from fumitm's printed summary.
 
 For more control, download the script first:
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ Script to automatically verify and fix MITM TLS distrust issues commonly afflict
 
 ```bash
 # Fix everything in one shot (no prompts, no download needed)
-python3 <(curl -LsSf https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py) --fix --yes &&
-  . "$HOME/.config/fumitm/env.sh"
+python3 <(curl -LsSf https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py) --fix --yes
+[ -r "$HOME/.config/fumitm/env.sh" ] && . "$HOME/.config/fumitm/env.sh"
 
 # With sudo (needed for Java keystores, DBeaver, and other system-level fixes)
-sudo python3 <(curl -LsSf https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py) --fix --yes --run-as-user $USER &&
-  . "$HOME/.config/fumitm/env.sh"
+sudo python3 <(curl -LsSf https://raw.githubusercontent.com/aberoham/fumitm/main/fumitm.py) --fix --yes --run-as-user $USER
+[ -r "$HOME/.config/fumitm/env.sh" ] && . "$HOME/.config/fumitm/env.sh"
 ```
 
-The trailing `. "$HOME/.config/fumitm/env.sh"` activates the new TLS environment in your current terminal. A child process cannot modify its parent shell, so without it the fixes only apply to newly opened shells.
+The second line activates the new TLS environment in your current terminal. A child process cannot modify its parent shell, so without it the fixes only apply to newly opened shells. It is a separate command rather than an `&&` chain so that a partial-success run (exit code 3 — some tools fixed, some not) still activates what was configured; it sources the file whenever it exists, which is exactly what any new shell would do.
 
 For more control, download the script first:
 

--- a/fumitm.py
+++ b/fumitm.py
@@ -6944,8 +6944,16 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
 
         Deliberately independent of shell_modified: on a converged rerun
         nothing on disk changes, but a freshly started wrapper process has
-        not inherited the environment and still needs this path to source
-        before launching dependent children.
+        not inherited the environment and still needs this path for its
+        dependent children.
+
+        Trust boundary: the file is owned and writable by the target user
+        (fumitm chowns it back after writing). A privileged wrapper must
+        never source it — that evaluates user-controlled shell code as
+        root. It should instead drop privileges and let the dependent
+        child source the file as the target user (e.g. via sudo -u). Only
+        the deterministic path is reported, never the file's contents,
+        precisely so nothing privileged is tempted to trust them.
         """
         if not self._uses_env_file(self.detect_shell()):
             return None

--- a/fumitm.py
+++ b/fumitm.py
@@ -6891,6 +6891,10 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             'partial': partial,
             'failed': failed,
             'exit_code': exit_code,
+            'shell_reload_required': self.shell_modified,
+            'shell_reload_command': (
+                self._shell_reload_command() if self.shell_modified else None
+            ),
         }
         # Stable machine-parseable line for Ansible changed_when
         print(f"FUMITM_RESULT: {json.dumps(result_obj)}")
@@ -6911,6 +6915,51 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             self._json_log_file_handle.flush()
 
         return exit_code
+
+    def _shell_reload_command(self):
+        """The exact command that activates fumitm's exports in the current shell.
+
+        POSIX shells source the small generated env file, never a whole rc
+        file: re-running .zshrc/.bashrc repeats unrelated agents, hooks,
+        aliases and PATH mutations that are not idempotent. fish keeps its
+        inline block in config.fish, so sourcing that file remains the fish
+        activation path. Returns None for shells with no safe one-liner.
+        """
+        shell_type = self.detect_shell()
+        if self._uses_env_file(shell_type):
+            return f'. {self._FUMITM_ENV_FILE_SHELL}'
+        if shell_type == 'fish':
+            home = os.path.expanduser("~")
+            return f"source {self.get_shell_config(shell_type).replace(home, '~', 1)}"
+        return None
+
+    def _print_shell_reload_notice(self):
+        """Final, unmissable instruction to activate exports in this shell.
+
+        A child process cannot modify its parent shell's environment, so after
+        a --fix the invoking terminal still carries the old variables until the
+        user sources the env file (or the chained README command does it for
+        them). Printed last so it is not buried under later informational
+        output. Suppressed in headless mode: a root Jamf/MDM policy log has no
+        interactive shell for the instruction to act on; automation reads the
+        shell_reload_* fields in FUMITM_RESULT instead.
+        """
+        if not self.shell_modified or self.headless:
+            return
+        command = self._shell_reload_command()
+        print()
+        self.print_warn("=" * 60)
+        self.print_warn("CURRENT SHELL NOT YET UPDATED")
+        self.print_warn("=" * 60)
+        self.print_warn("Environment changes only apply to new shells.")
+        self.print_warn("To activate them in THIS terminal, run:")
+        print()
+        if command:
+            self.print_info(f"  {command}")
+        else:
+            self.print_info("  exec $SHELL -l  (restarts your shell)")
+        print()
+        self.print_info("Or simply open a new terminal window.")
 
     def main(self):
         """Main entry point for the FumitmPython instance."""
@@ -7037,19 +7086,10 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                 if any_container_processed:
                     self._print_docker_build_hint()
 
-                if self.shell_modified:
-                    self.print_warn("Shell configuration was modified.")
-                    self.print_warn("Please reload your shell configuration:")
-                    shell_type = self.detect_shell()
-                    shell_config = self.get_shell_config(shell_type)
-                    if shell_type in ('bash', 'zsh', 'fish'):
-                        self.print_info(f"  source {shell_config}")
-                    else:
-                        self.print_info("  Please restart your shell")
-
                 print()
                 self.print_info(f"Certificate location: {self.cert_path}")
                 self.print_info("For additional applications, please refer to the documentation.")
+                self._print_shell_reload_notice()
                 return exit_code
 
             print()

--- a/fumitm.py
+++ b/fumitm.py
@@ -6895,9 +6895,7 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             'shell_reload_command': (
                 self._shell_reload_command() if self.shell_modified else None
             ),
-            'shell_env_file': (
-                self._shell_env_file() if self.shell_modified else None
-            ),
+            'shell_env_file': self._shell_env_file(),
         }
         # Stable machine-parseable line for Ansible changed_when
         print(f"FUMITM_RESULT: {json.dumps(result_obj)}")
@@ -6936,17 +6934,23 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
         return None
 
     def _shell_env_file(self):
-        """Absolute path of the generated env file, or None without one.
+        """Absolute path of the generated env file when it exists, else None.
 
         Reported in FUMITM_RESULT for automation wrappers: a root Jamf
         process using --run-as-user writes the target user's env file, but
         shell_reload_command is $HOME-relative and would resolve against the
         wrapper's own $HOME (/var/root). This path is absolute and already
         resolved against the target user's corrected home directory.
+
+        Deliberately independent of shell_modified: on a converged rerun
+        nothing on disk changes, but a freshly started wrapper process has
+        not inherited the environment and still needs this path to source
+        before launching dependent children.
         """
-        if self._uses_env_file(self.detect_shell()):
-            return self._env_file_path()
-        return None
+        if not self._uses_env_file(self.detect_shell()):
+            return None
+        path = self._env_file_path()
+        return path if os.path.exists(path) else None
 
     def _print_shell_reload_notice(self):
         """Final, unmissable instruction to activate exports in this shell.

--- a/fumitm.py
+++ b/fumitm.py
@@ -6895,6 +6895,9 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
             'shell_reload_command': (
                 self._shell_reload_command() if self.shell_modified else None
             ),
+            'shell_env_file': (
+                self._shell_env_file() if self.shell_modified else None
+            ),
         }
         # Stable machine-parseable line for Ansible changed_when
         print(f"FUMITM_RESULT: {json.dumps(result_obj)}")
@@ -6921,16 +6924,28 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
 
         POSIX shells source the small generated env file, never a whole rc
         file: re-running .zshrc/.bashrc repeats unrelated agents, hooks,
-        aliases and PATH mutations that are not idempotent. fish keeps its
-        inline block in config.fish, so sourcing that file remains the fish
-        activation path. Returns None for shells with no safe one-liner.
+        aliases and PATH mutations that are not idempotent. Returns None for
+        shells with no safe one-liner — including fish, which cannot source
+        the POSIX env file and whose config.fish would repeat the same
+        non-idempotent startup work; fish users get the new-session fallback
+        until a dedicated fish env file exists.
         """
         shell_type = self.detect_shell()
         if self._uses_env_file(shell_type):
             return f'. {self._FUMITM_ENV_FILE_SHELL}'
-        if shell_type == 'fish':
-            home = os.path.expanduser("~")
-            return f"source {self.get_shell_config(shell_type).replace(home, '~', 1)}"
+        return None
+
+    def _shell_env_file(self):
+        """Absolute path of the generated env file, or None without one.
+
+        Reported in FUMITM_RESULT for automation wrappers: a root Jamf
+        process using --run-as-user writes the target user's env file, but
+        shell_reload_command is $HOME-relative and would resolve against the
+        wrapper's own $HOME (/var/root). This path is absolute and already
+        resolved against the target user's corrected home directory.
+        """
+        if self._uses_env_file(self.detect_shell()):
+            return self._env_file_path()
         return None
 
     def _print_shell_reload_notice(self):

--- a/test_suite/test_headless_mdm.py
+++ b/test_suite/test_headless_mdm.py
@@ -930,12 +930,13 @@ class TestShellReloadNotice(FumitmTestCase):
             with patch.object(instance, 'detect_shell', return_value=shell):
                 assert instance._shell_reload_command() == self.ENV_SOURCE_CMD
 
-    def test_reload_command_fish_sources_config_fish(self):
-        """fish cannot source POSIX sh, so it keeps sourcing config.fish."""
+    def test_reload_command_fish_is_none(self):
+        """fish cannot source POSIX sh, and re-sourcing config.fish would
+        repeat non-idempotent startup work; fish gets the new-session
+        fallback until a dedicated fish env file exists."""
         instance = self.create_fumitm_instance()
         with patch.object(instance, 'detect_shell', return_value='fish'):
-            cmd = instance._shell_reload_command()
-        assert cmd == 'source ~/.config/fish/config.fish'
+            assert instance._shell_reload_command() is None
 
     def test_reload_command_unknown_shell_is_none(self):
         instance = self.create_fumitm_instance()
@@ -979,6 +980,31 @@ class TestShellReloadNotice(FumitmTestCase):
         instance._print_summary([ToolResult('a', 'already_ok', '')])
         data = self._parse_result(capsys.readouterr().out)
         assert data['shell_reload_required'] is False
+        assert data['shell_reload_command'] is None
+        assert data['shell_env_file'] is None
+
+    def test_result_json_env_file_is_absolute_target_path(self, capsys):
+        """shell_env_file must be usable by an automation wrapper whose own
+        $HOME differs from the target user's (root Jamf + --run-as-user):
+        absolute and resolved against the corrected home, unlike the
+        $HOME-relative shell_reload_command."""
+        instance = self.create_fumitm_instance()
+        instance.shell_modified = True
+        with patch.object(instance, 'detect_shell', return_value='zsh'):
+            instance._print_summary([ToolResult('a', 'configured', 'done')])
+        data = self._parse_result(capsys.readouterr().out)
+        assert data['shell_env_file'] == instance._env_file_path()
+        assert os.path.isabs(data['shell_env_file'])
+        assert '$HOME' not in data['shell_env_file']
+        assert data['shell_env_file'].endswith('.config/fumitm/env.sh')
+
+    def test_result_json_env_file_none_for_fish(self, capsys):
+        instance = self.create_fumitm_instance()
+        instance.shell_modified = True
+        with patch.object(instance, 'detect_shell', return_value='fish'):
+            instance._print_summary([ToolResult('a', 'configured', 'done')])
+        data = self._parse_result(capsys.readouterr().out)
+        assert data['shell_env_file'] is None
         assert data['shell_reload_command'] is None
 
 

--- a/test_suite/test_headless_mdm.py
+++ b/test_suite/test_headless_mdm.py
@@ -911,5 +911,76 @@ class TestSudoHelperUpdates(FumitmTestCase):
                 mock_getpwuid.assert_called_with(501)
 
 
+class TestShellReloadNotice(FumitmTestCase):
+    """Issue #100: activation guidance for the invoking shell after --fix."""
+
+    ENV_SOURCE_CMD = '. "$HOME/.config/fumitm/env.sh"'
+
+    @staticmethod
+    def _parse_result(output):
+        for line in output.splitlines():
+            if line.startswith('FUMITM_RESULT:'):
+                return json.loads(line.split(':', 1)[1].strip())
+        raise AssertionError('FUMITM_RESULT line not found')
+
+    def test_reload_command_posix_sources_env_file(self):
+        """POSIX shells get the env file, never a whole rc file."""
+        instance = self.create_fumitm_instance()
+        for shell in ('zsh', 'bash'):
+            with patch.object(instance, 'detect_shell', return_value=shell):
+                assert instance._shell_reload_command() == self.ENV_SOURCE_CMD
+
+    def test_reload_command_fish_sources_config_fish(self):
+        """fish cannot source POSIX sh, so it keeps sourcing config.fish."""
+        instance = self.create_fumitm_instance()
+        with patch.object(instance, 'detect_shell', return_value='fish'):
+            cmd = instance._shell_reload_command()
+        assert cmd == 'source ~/.config/fish/config.fish'
+
+    def test_reload_command_unknown_shell_is_none(self):
+        instance = self.create_fumitm_instance()
+        with patch.object(instance, 'detect_shell', return_value='csh'):
+            assert instance._shell_reload_command() is None
+
+    def test_notice_printed_when_shell_modified(self, capsys):
+        instance = self.create_fumitm_instance()
+        instance.shell_modified = True
+        with patch.object(instance, 'detect_shell', return_value='zsh'):
+            instance._print_shell_reload_notice()
+        out = capsys.readouterr().out
+        assert 'CURRENT SHELL NOT YET UPDATED' in out
+        assert self.ENV_SOURCE_CMD in out
+        assert '.zshrc' not in out
+
+    def test_notice_suppressed_without_shell_changes(self, capsys):
+        instance = self.create_fumitm_instance()
+        instance.shell_modified = False
+        instance._print_shell_reload_notice()
+        assert 'CURRENT SHELL' not in capsys.readouterr().out
+
+    def test_notice_suppressed_in_headless_mode(self, capsys):
+        """A root Jamf/MDM policy log has no shell the instruction can act on."""
+        instance = self.create_fumitm_instance(headless=True)
+        instance.shell_modified = True
+        instance._print_shell_reload_notice()
+        assert 'CURRENT SHELL' not in capsys.readouterr().out
+
+    def test_result_json_reload_fields_when_modified(self, capsys):
+        instance = self.create_fumitm_instance()
+        instance.shell_modified = True
+        with patch.object(instance, 'detect_shell', return_value='zsh'):
+            instance._print_summary([ToolResult('a', 'configured', 'done')])
+        data = self._parse_result(capsys.readouterr().out)
+        assert data['shell_reload_required'] is True
+        assert data['shell_reload_command'] == self.ENV_SOURCE_CMD
+
+    def test_result_json_reload_fields_when_not_modified(self, capsys):
+        instance = self.create_fumitm_instance()
+        instance._print_summary([ToolResult('a', 'already_ok', '')])
+        data = self._parse_result(capsys.readouterr().out)
+        assert data['shell_reload_required'] is False
+        assert data['shell_reload_command'] is None
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/test_suite/test_headless_mdm.py
+++ b/test_suite/test_headless_mdm.py
@@ -7,6 +7,9 @@ accuracy, exit codes, and orchestrator environment simulations.
 """
 import json
 import os
+import re
+import shutil
+import subprocess
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -975,6 +978,13 @@ class TestShellReloadNotice(FumitmTestCase):
         assert data['shell_reload_required'] is True
         assert data['shell_reload_command'] == self.ENV_SOURCE_CMD
 
+    @staticmethod
+    def _create_env_file(instance):
+        path = Path(instance._env_file_path())
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('export SSL_CERT_FILE="/b.pem"\n')
+        return str(path)
+
     def test_result_json_reload_fields_when_not_modified(self, capsys):
         instance = self.create_fumitm_instance()
         instance._print_summary([ToolResult('a', 'already_ok', '')])
@@ -990,6 +1000,7 @@ class TestShellReloadNotice(FumitmTestCase):
         $HOME-relative shell_reload_command."""
         instance = self.create_fumitm_instance()
         instance.shell_modified = True
+        self._create_env_file(instance)
         with patch.object(instance, 'detect_shell', return_value='zsh'):
             instance._print_summary([ToolResult('a', 'configured', 'done')])
         data = self._parse_result(capsys.readouterr().out)
@@ -997,6 +1008,20 @@ class TestShellReloadNotice(FumitmTestCase):
         assert os.path.isabs(data['shell_env_file'])
         assert '$HOME' not in data['shell_env_file']
         assert data['shell_env_file'].endswith('.config/fumitm/env.sh')
+
+    def test_result_json_env_file_reported_on_converged_rerun(self, capsys):
+        """A converged rerun changes nothing on disk, but a freshly started
+        wrapper process has not inherited the environment: shell_env_file
+        must still point at the existing env file while
+        shell_reload_required stays false."""
+        instance = self.create_fumitm_instance()
+        self._create_env_file(instance)
+        with patch.object(instance, 'detect_shell', return_value='zsh'):
+            instance._print_summary([ToolResult('a', 'already_ok', '')])
+        data = self._parse_result(capsys.readouterr().out)
+        assert data['shell_reload_required'] is False
+        assert data['shell_reload_command'] is None
+        assert data['shell_env_file'] == instance._env_file_path()
 
     def test_result_json_env_file_none_for_fish(self, capsys):
         instance = self.create_fumitm_instance()
@@ -1006,6 +1031,84 @@ class TestShellReloadNotice(FumitmTestCase):
         data = self._parse_result(capsys.readouterr().out)
         assert data['shell_env_file'] is None
         assert data['shell_reload_command'] is None
+
+
+class TestReadmeActivationBlock(FumitmTestCase):
+    """The README copy/paste block must activate on partial success while
+    preserving fumitm's exit status as the block's final status."""
+
+    @staticmethod
+    def _readme_block():
+        readme = Path(__file__).resolve().parent.parent / 'README.md'
+        lines = readme.read_text().splitlines()
+        for i, line in enumerate(lines):
+            if line.startswith('_fumitm_status=0; python3 <(curl'):
+                return lines[i:i + 3]
+        raise AssertionError('activation block not found in README.md')
+
+    def _stubbed_script(self, status):
+        """The real README block with the curl|python line stubbed out."""
+        block = self._readme_block()
+        first = re.sub(r"python3 <\(curl [^)]*\) --fix --yes",
+                       f"sh -c 'exit {status}'", block[0])
+        assert first != block[0], 'stub substitution did not match'
+        return '\n'.join([first] + block[1:])
+
+    def test_block_structure(self):
+        block = self._readme_block()
+        assert block[0].startswith('_fumitm_status=0; ')
+        assert block[0].endswith('|| _fumitm_status=$?')
+        assert block[1] == ('[ -r "$HOME/.config/fumitm/env.sh" ] && '
+                            '. "$HOME/.config/fumitm/env.sh"')
+        assert block[2] == '(exit $_fumitm_status)'
+
+    @pytest.mark.parametrize('shell', ['bash', 'zsh'])
+    @pytest.mark.parametrize(('status', 'with_file'), [
+        (0, True), (0, False), (1, False), (3, True),
+    ])
+    def test_block_preserves_status_and_activates(
+            self, isolate_home, shell, status, with_file):
+        if shutil.which(shell) is None:
+            pytest.skip(f'{shell} not installed')
+        if with_file:
+            env_dir = isolate_home / '.config' / 'fumitm'
+            env_dir.mkdir(parents=True)
+            (env_dir / 'env.sh').write_text(
+                'export SSL_CERT_FILE="/b.pem"\n')
+        script = self._stubbed_script(status)
+        env = {'HOME': str(isolate_home),
+               'PATH': os.environ.get('PATH', '/usr/bin:/bin')}
+        proc = subprocess.run([shell, '-c', script], env=env,
+                              capture_output=True, text=True, timeout=30,
+                              check=False)
+        assert proc.returncode == status, \
+            f'block status {proc.returncode} != fumitm status {status}'
+        probe = subprocess.run(
+            [shell, '-c', script + '\necho "var:${SSL_CERT_FILE:-none}"'],
+            env=env, capture_output=True, text=True, timeout=30, check=False)
+        expected = '/b.pem' if with_file else 'none'
+        assert f'var:{expected}' in probe.stdout
+
+    @pytest.mark.parametrize('shell', ['bash', 'zsh'])
+    def test_block_activates_before_errexit_stop(self, isolate_home, shell):
+        """Under set -e, a partial-success status must not stop the script
+        before the activation line runs; the script then stops with
+        fumitm's status, faithfully reflecting the failure."""
+        if shutil.which(shell) is None:
+            pytest.skip(f'{shell} not installed')
+        env_dir = isolate_home / '.config' / 'fumitm'
+        env_dir.mkdir(parents=True)
+        (env_dir / 'env.sh').write_text('export SSL_CERT_FILE="/b.pem"\n')
+        script = ('set -e\n'
+                  + self._stubbed_script(3)
+                  + '\necho unreachable')
+        env = {'HOME': str(isolate_home),
+               'PATH': os.environ.get('PATH', '/usr/bin:/bin')}
+        proc = subprocess.run([shell, '-c', script], env=env,
+                              capture_output=True, text=True, timeout=30,
+                              check=False)
+        assert proc.returncode == 3
+        assert 'unreachable' not in proc.stdout
 
 
 if __name__ == '__main__':

--- a/test_suite/test_headless_mdm.py
+++ b/test_suite/test_headless_mdm.py
@@ -8,9 +8,11 @@ accuracy, exit codes, and orchestrator environment simulations.
 import json
 import os
 import re
+import select
 import shutil
 import subprocess
 import tempfile
+import time
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -1060,7 +1062,8 @@ class TestReadmeActivationBlock(FumitmTestCase):
         assert block[0].endswith('|| _fumitm_status=$?')
         assert block[1] == ('[ -r "$HOME/.config/fumitm/env.sh" ] && '
                             '. "$HOME/.config/fumitm/env.sh"')
-        assert block[2] == '(exit $_fumitm_status)'
+        assert block[2] == ('case $- in *i*) ;; '
+                            '*) (exit "$_fumitm_status");; esac')
 
     @pytest.mark.parametrize('shell', ['bash', 'zsh'])
     @pytest.mark.parametrize(('status', 'with_file'), [
@@ -1109,6 +1112,107 @@ class TestReadmeActivationBlock(FumitmTestCase):
                               check=False)
         assert proc.returncode == 3
         assert 'unreachable' not in proc.stdout
+
+    @staticmethod
+    def _interactive_flags(shell):
+        """Flags for a clean interactive shell that reads no startup files."""
+        return (['--noprofile', '--norc', '-i'] if shell == 'bash'
+                else ['-f', '-i'])
+
+    @pytest.mark.parametrize('shell', ['bash', 'zsh'])
+    @pytest.mark.parametrize('status', [0, 1, 3])
+    def test_block_survives_interactive_errexit(
+            self, isolate_home, shell, status):
+        """An interactive shell with set -e must survive the block whatever
+        fumitm's exit status. A bare failing `(exit N)` is a top-level
+        command, so errexit would terminate the session instead of
+        returning to the prompt; the `case $- in *i*)` guard skips status
+        restoration in interactive shells."""
+        if shutil.which(shell) is None:
+            pytest.skip(f'{shell} not installed')
+        script = ('set -e\n'
+                  + self._stubbed_script(status)
+                  + '\necho SURVIVED')
+        env = {'HOME': str(isolate_home),
+               'PATH': os.environ.get('PATH', '/usr/bin:/bin')}
+        proc = subprocess.run(
+            [shell, *self._interactive_flags(shell), '-c', script],
+            env=env, capture_output=True, text=True, timeout=30,
+            check=False)
+        assert proc.returncode == 0, \
+            f'interactive {shell} exited {proc.returncode} instead of surviving'
+        assert 'SURVIVED' in proc.stdout
+
+    @pytest.mark.parametrize('shell', ['bash', 'zsh'])
+    def test_block_pasted_into_pty_returns_prompt(self, isolate_home, shell):
+        """The primary README use case: paste the block into an
+        already-running interactive shell on a real terminal — with
+        errexit enabled and fumitm failing — and get the prompt back."""
+        pty = pytest.importorskip('pty')
+        if shutil.which(shell) is None:
+            pytest.skip(f'{shell} not installed')
+        env = {'HOME': str(isolate_home), 'TERM': 'dumb',
+               'PATH': os.environ.get('PATH', '/usr/bin:/bin')}
+        master, slave = pty.openpty()
+        try:
+            proc = subprocess.Popen(
+                [shell, *self._interactive_flags(shell)],
+                stdin=slave, stdout=slave, stderr=slave,
+                env=env, start_new_session=True, close_fds=True)
+            os.close(slave)
+            slave = None
+            # `$?` in the marker stays literal in the echoed input but
+            # expands in the output, so `SURVIVED:0` proves the shell
+            # executed the line rather than merely echoing the paste.
+            typed = ('set -e\n'
+                     + self._stubbed_script(3)
+                     + '\necho SURVIVED:$?\nexit\n')
+            os.write(master, typed.encode())
+            output = b''
+            deadline = time.monotonic() + 30
+            while time.monotonic() < deadline:
+                ready, _, _ = select.select([master], [], [], 1)
+                if not ready:
+                    if proc.poll() is not None:
+                        break
+                    continue
+                try:
+                    chunk = os.read(master, 4096)
+                except OSError:
+                    break  # EIO: shell exited and the slave side closed
+                if not chunk:
+                    break
+                output += chunk
+            proc.wait(timeout=10)
+        finally:
+            os.close(master)
+            if slave is not None:
+                os.close(slave)
+        assert b'SURVIVED:0' in output, \
+            f'shell died before the prompt returned; output: {output!r}'
+        assert proc.returncode == 0
+
+
+class TestShellEnvFileTrustBoundary(FumitmTestCase):
+    """shell_env_file points at a target-user-writable file. The automation
+    docs and the reporting code must direct privileged wrappers to drop
+    privileges rather than source it as root (privilege-escalation risk)."""
+
+    def test_automation_docs_forbid_privileged_sourcing(self):
+        doc = (Path(__file__).resolve().parent.parent
+               / 'README-automation.md').read_text()
+        start = doc.index('`shell_env_file`')
+        section = doc[start:start + 1500]
+        assert 'must never source' in section
+        assert 'sudo -u' in section, \
+            'docs must show the privilege-drop pattern for dependent children'
+        assert 'needs to source this path' not in doc, \
+            'docs must not instruct the (possibly root) wrapper to source'
+
+    def test_shell_env_file_docstring_states_boundary(self):
+        doc = fumitm.FumitmPython._shell_env_file.__doc__
+        assert 'never source' in doc
+        assert 'drop privileges' in doc
 
 
 if __name__ == '__main__':

--- a/test_suite/test_headless_mdm.py
+++ b/test_suite/test_headless_mdm.py
@@ -1214,6 +1214,33 @@ class TestShellEnvFileTrustBoundary(FumitmTestCase):
         assert 'never source' in doc
         assert 'drop privileges' in doc
 
+    def test_privilege_drop_example_executes(self, tmp_path):
+        """Run the documented privilege-drop pattern verbatim (minus sudo)
+        and assert the child actually receives the environment. The
+        wrapper's $env_file variable is not visible inside the
+        single-quoted `sh -c` body, so the example must deliver the path
+        as a positional argument; an example that references $env_file
+        inside the quotes fails before launching the child."""
+        doc = (Path(__file__).resolve().parent.parent
+               / 'README-automation.md').read_text()
+        match = re.search(r'^\s*sudo -u "\$target_user" (sh -c .*)$',
+                          doc, re.M)
+        assert match, 'privilege-drop example not found in automation docs'
+        example = match.group(1).replace(
+            'dependent-command', 'printenv SSL_CERT_FILE')
+        env_file = tmp_path / 'env.sh'
+        env_file.write_text('export SSL_CERT_FILE="/b.pem"\n')
+        # env_file is deliberately a plain (unexported) wrapper variable,
+        # exactly as a Jamf/Ansible wrapper script would hold it.
+        script = f"env_file='{env_file}'\n{example}\n"
+        proc = subprocess.run(
+            ['sh', '-c', script],
+            env={'PATH': os.environ.get('PATH', '/usr/bin:/bin')},
+            capture_output=True, text=True, timeout=30, check=False)
+        assert proc.returncode == 0, \
+            f'documented example failed: {proc.stderr!r}'
+        assert proc.stdout.strip() == '/b.pem'
+
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
Implements Option A from #100: a child process cannot change its parent shell's environment, so activation of the current shell is made an explicit step, surfaced everywhere it is actionable.

## Changes

- **README one-liners** run fumitm, then source `"$HOME/.config/fumitm/env.sh"` whenever it exists — including after a partial-success run (exit 3), which is exactly what any new shell would do. The block's final line, `case $- in *i*) ;; *) (exit "$_fumitm_status");; esac`, restores fumitm's exit status in non-interactive shells only: a wrapper script sees the real status as `$?` and, under `set -e`, stops there — after activation has run. Interactive shells skip restoration, so pasting the block into a terminal always returns to the prompt even with `set -e` enabled, where a restored failure status would otherwise terminate the session; the outcome is read from fumitm's printed summary.
- **End-of-run banner** `CURRENT SHELL NOT YET UPDATED` is printed as the very last output with the per-shell activation command. POSIX shells source the small generated env file, never the whole rc file (re-running `.zshrc`/`.bashrc` repeats non-idempotent startup work); fish and shells with no safe one-liner get `exec $SHELL -l`. Suppressed under `--headless`, where no interactive shell exists to act on it.
- **`FUMITM_RESULT` gains `shell_reload_required`, `shell_reload_command`, and `shell_env_file`.** `shell_reload_command` is for the end user's own shell and is `$HOME`-relative; automation must not use it. `shell_env_file` is the absolute path resolved against the target user's home, reported whenever the file exists — including converged reruns, where a freshly started wrapper has not inherited the environment. README-automation.md documents the trust boundary: the file is owned and writable by the target user, so a privileged wrapper must never source or evaluate it; a dependent child gets the environment by dropping privileges, with the path passed as a positional argument into `sh -c` (the wrapper's variable is not visible inside the quoted body):

  ```bash
  sudo -u "$target_user" sh -c '. "$1" && exec dependent-command' sh "$env_file"
  ```

Exit codes are unchanged.

## Tests

In `test_suite/test_headless_mdm.py`: `TestShellReloadNotice` (per-shell reload command, banner presence and suppression, new JSON fields), `TestReadmeActivationBlock` (executes the actual README block from the file in bash and zsh — script mode with and without `set -e`, interactive `-i -c`, and a real-PTY paste with `errexit` enabled and fumitm failing), and `TestShellEnvFileTrustBoundary` (docs contract for the privilege boundary, plus an executable run of the documented `sudo -u` example verifying the child receives the environment). Full Unix suite: 440 passed.

Option B (passive generation-aware refresh hook) is stacked on this PR as #102.

Part of #100 — the issue is closed by #102, the final PR in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSBN7x4y3eQjAGN8iDtcSp
