### PR TITLE
Fix Gradle custom cacerts regeneration

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Something amiss or not quite right? Please post the full output of a run to an i
 - **Rancher Desktop**: installs certificate in `~/.docker/certs.d/` (persistent) and Rancher VM's trust store (if running)
 - **Colima**: installs certificate in `~/.docker/certs.d/` (persistent, applied on start) and Colima VM's trust store (if running)
 - **Android Emulator**: helps install certificate on running Android emulators
-- **Gradle**: sets `systemProp` entries in `gradle.properties` (respecting `GRADLE_USER_HOME`) for the provider certificate.
+- **Gradle**: rebuilds `~/.gradle/custom-cacerts` (respecting `GRADLE_USER_HOME`) as a PKCS12 truststore seeded from the active Java `cacerts`, imports the current proxy CA chain, and points `gradle.properties` at that managed store.
  
 ### Windows
 - **Node.js/npm**: configures `NODE_EXTRA_CA_CERTS` for Node.js and the cafile setting for npm

--- a/fumitm.py
+++ b/fumitm.py
@@ -1867,6 +1867,11 @@ class FumitmPython:
         gradle_home = os.environ.get('GRADLE_USER_HOME', os.path.expanduser('~/.gradle'))
         return os.path.join(gradle_home, 'gradle.properties')
 
+    def get_gradle_custom_cacerts_path(self):
+        """Return the managed PKCS12 truststore path for Gradle."""
+        gradle_home = os.environ.get('GRADLE_USER_HOME', os.path.expanduser('~/.gradle'))
+        return os.path.join(gradle_home, 'custom-cacerts')
+
     def read_properties_file(self, path):
         """Read Java-style .properties file into a dict."""
         props = {}
@@ -1887,31 +1892,35 @@ class FumitmPython:
                 existing_lines = f.readlines()
 
         current_props = {}
+        key_counts = {key: 0 for key in props_to_set}
         for line in existing_lines:
             line = line.strip()
             if '=' in line and not line.startswith('#'):
                 key, val = line.split('=', 1)
                 current_props[key] = val
+                if key in key_counts:
+                    key_counts[key] += 1
 
-        if all(current_props.get(k) == v for k, v in props_to_set.items()):
+        if (all(current_props.get(k) == v for k, v in props_to_set.items())
+                and all(key_counts[key] == 1 for key in props_to_set)):
             return False
 
         self.print_info(f"Setting up {desc}...")
 
         updated_lines = []
-        remaining = props_to_set.copy()
+        managed_keys = set(props_to_set)
         for line in existing_lines:
             stripped = line.strip()
-            replaced = False
-            for key in list(remaining):
-                if stripped.startswith(key + '='):
-                    updated_lines.append(f"{key}={remaining.pop(key)}\n")
-                    replaced = True
-                    break
-            if not replaced:
-                updated_lines.append(line)
+            if any(stripped.startswith(key + '=') for key in managed_keys):
+                continue
+            updated_lines.append(line)
 
-        for key, value in remaining.items():
+        while updated_lines and updated_lines[-1].strip() == '':
+            updated_lines.pop()
+        if updated_lines:
+            updated_lines.append('\n')
+
+        for key, value in props_to_set.items():
             updated_lines.append(f"{key}={value}\n")
 
         if not self.is_install_mode():
@@ -2992,19 +3001,85 @@ class FumitmPython:
         )
         return pairs
 
-    def _keytool_alias_present(self, keytool_bin, keystore, alias):
-        """Return True if alias is already present in the Java keystore."""
+    def _split_pem_certificates(self, cert_path):
+        """Return each PEM certificate in cert_path as a standalone string."""
+        try:
+            with open(cert_path, 'r') as f:
+                content = f.read()
+        except OSError:
+            return []
+
+        certs = []
+        current = []
+        in_cert = False
+        for line in content.splitlines():
+            if '-----BEGIN CERTIFICATE-----' in line:
+                current = ['-----BEGIN CERTIFICATE-----']
+                in_cert = True
+                continue
+            if not in_cert:
+                continue
+            current.append(line)
+            if '-----END CERTIFICATE-----' in line:
+                certs.append('\n'.join(current) + '\n')
+                current = []
+                in_cert = False
+        return certs
+
+    def _expanded_root_aliases(self):
+        """Return per-certificate (alias, path) pairs, splitting PEM chains."""
+        pairs = []
+        temp_paths = []
+        for alias, cert_path in self._all_root_aliases():
+            certs = self._split_pem_certificates(cert_path)
+            if len(certs) <= 1:
+                pairs.append((alias, cert_path))
+                continue
+            for idx, cert_text in enumerate(certs, start=1):
+                with tempfile.NamedTemporaryFile(
+                        mode='w', suffix='.pem', delete=False) as tf:
+                    tf.write(cert_text)
+                    temp_path = tf.name
+                temp_paths.append(temp_path)
+                expanded_alias = alias if idx == 1 else f'{alias}-{idx}'
+                pairs.append((expanded_alias, temp_path))
+        return pairs, temp_paths
+
+    def _detect_keystore_type(self, keystore, storepass='changeit'):
+        """Return the keystore type reported by keytool, or an empty string."""
         try:
             result = subprocess.run(
-                [keytool_bin, '-list', '-alias', alias,
-                 '-keystore', keystore, '-storepass', 'changeit'],
+                ['keytool', '-list', '-keystore', keystore, '-storepass', storepass],
+                capture_output=True, text=True, check=False
+            )
+        except Exception as e:
+            self.print_debug(f"Could not detect keystore type for {keystore}: {e}")
+            return ''
+
+        if result.returncode != 0:
+            return ''
+        for line in result.stdout.splitlines():
+            if line.lower().startswith('keystore type:'):
+                return line.split(':', 1)[1].strip()
+        return ''
+
+    def _keytool_alias_present(self, keytool_bin, keystore, alias, storetype=None):
+        """Return True if alias is already present in the Java keystore."""
+        try:
+            cmd = [keytool_bin, '-list', '-alias', alias,
+                   '-keystore', keystore, '-storepass', 'changeit']
+            if storetype:
+                cmd.extend(['-storetype', storetype])
+            result = subprocess.run(
+                cmd,
                 capture_output=True, check=False
             )
-            return result.returncode == 0 and alias in result.stdout.decode()
+            stdout = result.stdout.decode() if isinstance(result.stdout, bytes) else result.stdout
+            return result.returncode == 0 and alias in stdout
         except Exception:
             return False
 
-    def _ensure_roots_in_keystore(self, keytool_bin, keystore, label):
+    def _ensure_roots_in_keystore(self, keytool_bin, keystore, label, storetype=None):
         """Import every proxy root (primary + supplemental) into a Java keystore.
 
         Each root is imported under its own alias and skipped when already
@@ -3014,38 +3089,131 @@ class FumitmPython:
         """
         imported = False
         failed = False
-        for alias, cert_path in self._all_root_aliases():
-            if self._keytool_alias_present(keytool_bin, keystore, alias):
-                continue
-            if not self.is_install_mode():
-                self.print_action(f"    Would import {alias} certificate to: {keystore}")
-                imported = True
-                continue
-            result = subprocess.run(
-                [keytool_bin, '-import', '-trustcacerts', '-alias', alias,
-                 '-file', cert_path, '-keystore', keystore, '-storepass', 'changeit',
-                 '-noprompt'],
-                capture_output=True, text=True, check=False
-            )
-            if result.returncode == 0:
-                self.print_info(f"    ✓ {label}: {alias} added successfully")
-                imported = True
-            else:
-                self.print_warn(f"    ✗ {label}: Failed to add {alias} (may require sudo)")
-                self.print_info("      Fix with:")
-                print(f"        sudo {keytool_bin} -import -trustcacerts \\")
-                print(f"          -alias {alias} \\")
-                print(f"          -file {cert_path} \\")
-                print(f"          -keystore {keystore} \\")
-                print("          -storepass changeit -noprompt")
-                if result.stdout:
-                    self.print_warn(f"      Keytool response: {result.stdout}")
-                failed = True
+        alias_pairs, temp_paths = self._expanded_root_aliases()
+        try:
+            for alias, cert_path in alias_pairs:
+                if self._keytool_alias_present(keytool_bin, keystore, alias, storetype=storetype):
+                    continue
+                if not self.is_install_mode():
+                    self.print_action(f"    Would import {alias} certificate to: {keystore}")
+                    imported = True
+                    continue
+                cmd = [keytool_bin, '-import', '-trustcacerts', '-alias', alias,
+                       '-file', cert_path, '-keystore', keystore, '-storepass', 'changeit']
+                if storetype:
+                    cmd.extend(['-storetype', storetype])
+                cmd.append('-noprompt')
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True, text=True, check=False
+                )
+                if result.returncode == 0:
+                    self.print_info(f"    ✓ {label}: {alias} added successfully")
+                    imported = True
+                else:
+                    self.print_warn(f"    ✗ {label}: Failed to add {alias} (may require sudo)")
+                    self.print_info("      Fix with:")
+                    print(f"        sudo {keytool_bin} -import -trustcacerts \\")
+                    print(f"          -alias {alias} \\")
+                    print(f"          -file {cert_path} \\")
+                    print(f"          -keystore {keystore} \\")
+                    if storetype:
+                        print(f"          -storetype {storetype} \\")
+                    print("          -storepass changeit -noprompt")
+                    if result.stdout:
+                        self.print_warn(f"      Keytool response: {result.stdout}")
+                    failed = True
+        finally:
+            for path in temp_paths:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
         if failed and not imported:
             return 'failed'
         if imported:
             return 'configured'
         return 'already_ok'
+
+    def _gradle_custom_truststore_has_roots(self, gradle_cacerts):
+        """Return True if the managed Gradle truststore contains every proxy CA."""
+        if not os.path.exists(gradle_cacerts):
+            return False
+        alias_pairs, temp_paths = self._expanded_root_aliases()
+        try:
+            return all(
+                self._keytool_alias_present(
+                    'keytool', gradle_cacerts, alias, storetype='PKCS12'
+                )
+                for alias, _ in alias_pairs
+            )
+        finally:
+            for path in temp_paths:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+
+    def ensure_gradle_custom_truststore(self, source_cacerts, gradle_cacerts):
+        """Ensure Gradle's managed PKCS12 truststore exists and contains proxy roots."""
+        if self._gradle_custom_truststore_has_roots(gradle_cacerts):
+            return 'already_ok'
+
+        if not self.is_install_mode():
+            self.print_action(
+                f"Would rebuild Gradle PKCS12 truststore at {gradle_cacerts} "
+                f"from {source_cacerts}"
+            )
+            return 'skipped'
+
+        source_type = self._detect_keystore_type(source_cacerts)
+        if not source_type:
+            self.print_error(f"Could not determine keystore type for {source_cacerts}")
+            return 'failed'
+
+        self._safe_makedirs(os.path.dirname(gradle_cacerts))
+        fd, temp_keystore = tempfile.mkstemp(
+            prefix='custom-cacerts-', suffix='.p12', dir=os.path.dirname(gradle_cacerts)
+        )
+        os.close(fd)
+        try:
+            os.unlink(temp_keystore)
+        except OSError:
+            pass
+
+        try:
+            result = subprocess.run(
+                ['keytool', '-importkeystore', '-noprompt',
+                 '-srckeystore', source_cacerts, '-srcstorepass', 'changeit',
+                 '-srcstoretype', source_type,
+                 '-destkeystore', temp_keystore, '-deststorepass', 'changeit',
+                 '-deststoretype', 'PKCS12'],
+                capture_output=True, text=True, check=False
+            )
+            if result.returncode != 0:
+                self.print_error("Failed to seed Gradle custom truststore from Java cacerts")
+                if result.stdout:
+                    self.print_warn(result.stdout)
+                if result.stderr:
+                    self.print_warn(result.stderr)
+                return 'failed'
+
+            status = self._ensure_roots_in_keystore(
+                'keytool', temp_keystore, 'Gradle custom truststore', storetype='PKCS12'
+            )
+            if status == 'failed':
+                return 'failed'
+
+            shutil.move(temp_keystore, gradle_cacerts)
+            self._fix_ownership(gradle_cacerts)
+            self.print_info(f"Rebuilt Gradle custom truststore at {gradle_cacerts}")
+            return 'configured'
+        finally:
+            if os.path.exists(temp_keystore):
+                try:
+                    os.unlink(temp_keystore)
+                except OSError:
+                    pass
 
     def _all_container_certs(self):
         """Return (container_cert_name, cert_path) for the primary and each supplemental root."""
@@ -4766,17 +4934,23 @@ class FumitmPython:
             self.print_error("Could not find Java cacerts file for Gradle")
             return ToolResult('gradle', 'skipped', 'Java cacerts file not found')
 
+        gradle_cacerts = self.get_gradle_custom_cacerts_path()
+        truststore_status = self.ensure_gradle_custom_truststore(cacerts, gradle_cacerts)
+        if truststore_status == 'failed':
+            return ToolResult('gradle', 'failed', 'Failed to rebuild Gradle custom truststore')
+
         props_to_set = {
-            'systemProp.javax.net.ssl.trustStore': cacerts,
+            'systemProp.javax.net.ssl.trustStore': gradle_cacerts,
             'systemProp.javax.net.ssl.trustStorePassword': 'changeit',
+            'systemProp.javax.net.ssl.trustStoreType': 'PKCS12',
             'systemProp.https.protocols': 'TLSv1.2'
         }
 
         changed = self.update_properties_file(gradle_props, props_to_set, "Gradle properties")
-        if not changed:
+        if not changed and truststore_status == 'already_ok':
             return ToolResult('gradle', 'already_ok', 'Gradle properties already configured')
         if self.is_install_mode():
-            return ToolResult('gradle', 'configured', 'Updated Gradle properties')
+            return ToolResult('gradle', 'configured', 'Configured Gradle custom truststore')
         return ToolResult('gradle', 'skipped', 'Dry run')
 
     def setup_dbeaver_cert(self):
@@ -6269,10 +6443,11 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
         if self.command_exists('gradle') or os.path.exists(gradle_props):
             if os.path.exists(gradle_props):
                 current_props = self.read_properties_file(gradle_props)
-                cacerts = self.find_java_cacerts()
+                gradle_cacerts = self.get_gradle_custom_cacerts_path()
                 expected = {
-                    'systemProp.javax.net.ssl.trustStore': cacerts,
+                    'systemProp.javax.net.ssl.trustStore': gradle_cacerts,
                     'systemProp.javax.net.ssl.trustStorePassword': 'changeit',
+                    'systemProp.javax.net.ssl.trustStoreType': 'PKCS12',
                     'systemProp.https.protocols': 'TLSv1.2'
                 }
 
@@ -6283,6 +6458,11 @@ https.get('{test_url}', {{headers: {{'User-Agent': 'Mozilla/5.0'}}}}, (res) => {
                     else:
                         self.print_warn(f"  ✗ {key} not set correctly in Gradle properties")
                         has_issues = True
+                if self._gradle_custom_truststore_has_roots(gradle_cacerts):
+                    self.print_info("  ✓ Gradle custom truststore contains current proxy root(s)")
+                else:
+                    self.print_warn("  ✗ Gradle custom truststore is missing current proxy root(s)")
+                    has_issues = True
             else:
                 self.print_warn("  ✗ Gradle properties file not found")
                 has_issues = True

--- a/fumitm.py
+++ b/fumitm.py
@@ -1893,12 +1893,19 @@ class FumitmPython:
 
         current_props = {}
         key_counts = {key: 0 for key in props_to_set}
-        for line in existing_lines:
-            line = line.strip()
+        in_vendor_block = False
+        for raw_line in existing_lines:
+            line = raw_line.strip()
+            if line.startswith('#') and line.endswith('-start'):
+                in_vendor_block = True
+                continue
+            if line.startswith('#') and line.endswith('-end'):
+                in_vendor_block = False
+                continue
             if '=' in line and not line.startswith('#'):
                 key, val = line.split('=', 1)
                 current_props[key] = val
-                if key in key_counts:
+                if key in key_counts and not in_vendor_block:
                     key_counts[key] += 1
 
         if (all(current_props.get(k) == v for k, v in props_to_set.items())
@@ -1909,9 +1916,19 @@ class FumitmPython:
 
         updated_lines = []
         managed_keys = set(props_to_set)
+        in_vendor_block = False
         for line in existing_lines:
             stripped = line.strip()
-            if any(stripped.startswith(key + '=') for key in managed_keys):
+            if stripped.startswith('#') and stripped.endswith('-start'):
+                in_vendor_block = True
+                updated_lines.append(line)
+                continue
+            if stripped.startswith('#') and stripped.endswith('-end'):
+                in_vendor_block = False
+                updated_lines.append(line)
+                continue
+            if (not in_vendor_block
+                    and any(stripped.startswith(key + '=') for key in managed_keys)):
                 continue
             updated_lines.append(line)
 
@@ -3026,11 +3043,26 @@ class FumitmPython:
                 in_cert = False
         return certs
 
-    def _expanded_root_aliases(self):
-        """Return per-certificate (alias, path) pairs, splitting PEM chains."""
+    def _expanded_alias_names(self, alias_pairs):
+        """Return the alias names that a split PEM chain would import under."""
+        names = []
+        for alias, cert_path in alias_pairs:
+            certs = self._split_pem_certificates(cert_path)
+            if len(certs) <= 1:
+                names.append(alias)
+                continue
+            for idx, _ in enumerate(certs, start=1):
+                names.append(alias if idx == 1 else f'{alias}-{idx}')
+        return names
+
+    def _materialize_alias_pairs(self, alias_pairs, split_chains=False):
+        """Return importable (alias, path) pairs and temp files for PEM chains."""
+        if not split_chains:
+            return alias_pairs, []
+
         pairs = []
         temp_paths = []
-        for alias, cert_path in self._all_root_aliases():
+        for alias, cert_path in alias_pairs:
             certs = self._split_pem_certificates(cert_path)
             if len(certs) <= 1:
                 pairs.append((alias, cert_path))
@@ -3079,7 +3111,8 @@ class FumitmPython:
         except Exception:
             return False
 
-    def _ensure_roots_in_keystore(self, keytool_bin, keystore, label, storetype=None):
+    def _ensure_roots_in_keystore(self, keytool_bin, keystore, label, storetype=None,
+                                  alias_pairs=None, split_chains=False):
         """Import every proxy root (primary + supplemental) into a Java keystore.
 
         Each root is imported under its own alias and skipped when already
@@ -3089,7 +3122,10 @@ class FumitmPython:
         """
         imported = False
         failed = False
-        alias_pairs, temp_paths = self._expanded_root_aliases()
+        alias_pairs = alias_pairs if alias_pairs is not None else self._all_root_aliases()
+        alias_pairs, temp_paths = self._materialize_alias_pairs(
+            alias_pairs, split_chains=split_chains
+        )
         try:
             for alias, cert_path in alias_pairs:
                 if self._keytool_alias_present(keytool_bin, keystore, alias, storetype=storetype):
@@ -3139,20 +3175,13 @@ class FumitmPython:
         """Return True if the managed Gradle truststore contains every proxy CA."""
         if not os.path.exists(gradle_cacerts):
             return False
-        alias_pairs, temp_paths = self._expanded_root_aliases()
-        try:
-            return all(
-                self._keytool_alias_present(
-                    'keytool', gradle_cacerts, alias, storetype='PKCS12'
-                )
-                for alias, _ in alias_pairs
+        alias_names = self._expanded_alias_names(self._all_root_aliases())
+        return all(
+            self._keytool_alias_present(
+                'keytool', gradle_cacerts, alias, storetype='PKCS12'
             )
-        finally:
-            for path in temp_paths:
-                try:
-                    os.unlink(path)
-                except OSError:
-                    pass
+            for alias in alias_names
+        )
 
     def ensure_gradle_custom_truststore(self, source_cacerts, gradle_cacerts):
         """Ensure Gradle's managed PKCS12 truststore exists and contains proxy roots."""
@@ -3199,7 +3228,8 @@ class FumitmPython:
                 return 'failed'
 
             status = self._ensure_roots_in_keystore(
-                'keytool', temp_keystore, 'Gradle custom truststore', storetype='PKCS12'
+                'keytool', temp_keystore, 'Gradle custom truststore',
+                storetype='PKCS12', split_chains=True
             )
             if status == 'failed':
                 return 'failed'

--- a/test_suite/test_fumitm_integration.py
+++ b/test_suite/test_fumitm_integration.py
@@ -3462,10 +3462,101 @@ class TestBareReturnsFixed(FumitmTestCase):
         instance = self.create_fumitm_instance(mode='install')
         with patch.object(instance, 'command_exists', return_value=True), \
              patch.object(instance, 'find_java_cacerts', return_value='/fake/cacerts'), \
+             patch.object(instance, 'ensure_gradle_custom_truststore',
+                          return_value='already_ok'), \
              patch.object(instance, 'update_properties_file', return_value=False):
             result = instance.setup_gradle_cert()
             assert result.status == 'already_ok'
             assert result.tool == 'gradle'
+
+    def test_gradle_rewrites_duplicate_override_block_to_single_custom_store(self, tmp_path):
+        """setup_gradle_cert removes duplicate trustStore keys and writes one final block."""
+        instance = self.create_fumitm_instance(mode='install')
+        gradle_props = tmp_path / 'gradle.properties'
+        gradle_props.write_text(
+            'systemProp.javax.net.ssl.trustStore=/old/jdk/cacerts\n'
+            'systemProp.javax.net.ssl.trustStorePassword=changeit\n'
+            'systemProp.https.protocols=TLSv1.2\n'
+            '# aikido-endpoint-java-gradle-cert-config-start\n'
+            'systemProp.javax.net.ssl.trustStore=/vendor/custom-cacerts\n'
+            'systemProp.javax.net.ssl.trustStorePassword=changeit\n'
+            'systemProp.javax.net.ssl.trustStoreType=PKCS12\n'
+            '# aikido-endpoint-java-gradle-cert-config-end\n'
+        )
+
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.object(instance, 'find_java_cacerts', return_value='/fake/cacerts'), \
+             patch.object(instance, 'get_gradle_properties_path',
+                          return_value=str(gradle_props)), \
+             patch.object(instance, 'get_gradle_custom_cacerts_path',
+                          return_value='/Users/test/.gradle/custom-cacerts'), \
+             patch.object(instance, 'ensure_gradle_custom_truststore',
+                          return_value='already_ok'):
+            result = instance.setup_gradle_cert()
+
+        assert result.status == 'configured'
+        content = gradle_props.read_text()
+        assert content.count('systemProp.javax.net.ssl.trustStore=') == 1
+        assert content.count('systemProp.javax.net.ssl.trustStorePassword=') == 1
+        assert content.count('systemProp.javax.net.ssl.trustStoreType=') == 1
+        assert content.splitlines()[-4:] == [
+            'systemProp.javax.net.ssl.trustStore=/Users/test/.gradle/custom-cacerts',
+            'systemProp.javax.net.ssl.trustStorePassword=changeit',
+            'systemProp.javax.net.ssl.trustStoreType=PKCS12',
+            'systemProp.https.protocols=TLSv1.2',
+        ]
+
+    def test_gradle_custom_truststore_rebuild_imports_each_proxy_cert(self, tmp_path):
+        """ensure_gradle_custom_truststore rebuilds PKCS12 and imports each proxy cert."""
+        instance = self.create_fumitm_instance(mode='install')
+        source_cacerts = tmp_path / 'cacerts'
+        source_cacerts.write_text('placeholder')
+        gradle_cacerts = tmp_path / 'custom-cacerts'
+        netskope_chain = tmp_path / 'netskope-chain.pem'
+        netskope_chain.write_text(
+            mock_data.MOCK_CERTIFICATE + '\n' + mock_data.MOCK_AIKIDO_ROOT_CERT
+        )
+        aikido_root = tmp_path / 'aikido-root.pem'
+        aikido_root.write_text(mock_data.MOCK_AIKIDO_ROOT_CERT)
+
+        instance.cert_path = str(netskope_chain)
+        instance.extra_roots = [{
+            'key': 'aikido',
+            'name': 'Aikido Endpoint Protection',
+            'short_name': 'Aikido',
+            'keytool_alias': 'aikido-root',
+            'container_cert_name': 'aikido',
+            'path': str(aikido_root),
+        }]
+
+        def run_side_effect(cmd, **kwargs):
+            result = MagicMock(returncode=0, stdout='', stderr='')
+            if cmd[:2] == ['keytool', '-list']:
+                result.returncode = 1
+                result.stdout = b''
+            elif cmd[:2] == ['keytool', '-importkeystore']:
+                Path(cmd[cmd.index('-destkeystore') + 1]).write_text('seeded')
+            return result
+
+        with patch.object(instance, '_detect_keystore_type', return_value='JKS'), \
+             patch('subprocess.run', side_effect=run_side_effect) as mock_run:
+            result = instance.ensure_gradle_custom_truststore(
+                str(source_cacerts), str(gradle_cacerts)
+            )
+
+        assert result == 'configured'
+        commands = [call.args[0] for call in mock_run.call_args_list]
+        assert any(cmd[:2] == ['keytool', '-importkeystore'] for cmd in commands)
+        imported_aliases = [
+            cmd[cmd.index('-alias') + 1]
+            for cmd in commands
+            if cmd[:2] == ['keytool', '-import']
+        ]
+        assert imported_aliases == [
+            'cloudflare-zerotrust',
+            'cloudflare-zerotrust-2',
+            'aikido-root',
+        ]
 
 
 class TestAwsVerification(FumitmTestCase):

--- a/test_suite/test_fumitm_integration.py
+++ b/test_suite/test_fumitm_integration.py
@@ -3469,8 +3469,8 @@ class TestBareReturnsFixed(FumitmTestCase):
             assert result.status == 'already_ok'
             assert result.tool == 'gradle'
 
-    def test_gradle_rewrites_duplicate_override_block_to_single_custom_store(self, tmp_path):
-        """setup_gradle_cert removes duplicate trustStore keys and writes one final block."""
+    def test_gradle_rewrites_without_editing_vendor_override_block(self, tmp_path):
+        """setup_gradle_cert appends a final managed block without changing vendor markers."""
         instance = self.create_fumitm_instance(mode='install')
         gradle_props = tmp_path / 'gradle.properties'
         gradle_props.write_text(
@@ -3496,9 +3496,12 @@ class TestBareReturnsFixed(FumitmTestCase):
 
         assert result.status == 'configured'
         content = gradle_props.read_text()
-        assert content.count('systemProp.javax.net.ssl.trustStore=') == 1
-        assert content.count('systemProp.javax.net.ssl.trustStorePassword=') == 1
-        assert content.count('systemProp.javax.net.ssl.trustStoreType=') == 1
+        assert '# aikido-endpoint-java-gradle-cert-config-start\n' in content
+        assert 'systemProp.javax.net.ssl.trustStore=/vendor/custom-cacerts\n' in content
+        assert 'systemProp.javax.net.ssl.trustStoreType=PKCS12\n' in content
+        assert content.count('systemProp.javax.net.ssl.trustStore=') == 2
+        assert content.count('systemProp.javax.net.ssl.trustStorePassword=') == 2
+        assert content.count('systemProp.javax.net.ssl.trustStoreType=') == 2
         assert content.splitlines()[-4:] == [
             'systemProp.javax.net.ssl.trustStore=/Users/test/.gradle/custom-cacerts',
             'systemProp.javax.net.ssl.trustStorePassword=changeit',
@@ -3557,6 +3560,41 @@ class TestBareReturnsFixed(FumitmTestCase):
             'cloudflare-zerotrust-2',
             'aikido-root',
         ]
+
+    def test_java_keystore_import_does_not_split_pem_chain(self, tmp_path):
+        """setup_java_cert keeps the historical single-alias import behavior."""
+        instance = self.create_fumitm_instance(mode='install')
+        java_home = '/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home'
+        netskope_chain = tmp_path / 'netskope-chain.pem'
+        netskope_chain.write_text(
+            mock_data.MOCK_CERTIFICATE + '\n' + mock_data.MOCK_AIKIDO_ROOT_CERT
+        )
+        instance.cert_path = str(netskope_chain)
+        instance.extra_roots = []
+
+        def run_side_effect(cmd, **kwargs):
+            result = MagicMock()
+            if '-list' in cmd:
+                result.returncode = 1
+                result.stdout = b''
+            else:
+                result.returncode = 0
+                result.stdout = b'Certificate was added'
+            return result
+
+        with patch.object(instance, 'command_exists', return_value=True), \
+             patch.object(instance, 'find_all_java_homes', return_value=[java_home]), \
+             patch.object(instance, 'find_java_cacerts', return_value='/fake/cacerts'), \
+             patch('subprocess.run', side_effect=run_side_effect) as mock_run:
+            result = instance.setup_java_cert()
+
+        assert result.status == 'configured'
+        imported_aliases = [
+            cmd[cmd.index('-alias') + 1]
+            for cmd in (call.args[0] for call in mock_run.call_args_list)
+            if cmd[:2] == ['keytool', '-import']
+        ]
+        assert imported_aliases == ['cloudflare-zerotrust']
 
 
 class TestAwsVerification(FumitmTestCase):


### PR DESCRIPTION
## What changed
- Rebuild the managed Gradle `custom-cacerts` truststore as PKCS12 seeded from the active Java `cacerts`.
- Import every proxy certificate in a PEM chain under separate aliases, including the current THG Netskope intermediate (`ca.thg.goskope.com`).
- Rewrite duplicate Gradle `systemProp` entries so the fumitm-managed truststore settings win by last occurrence.
- Add regression coverage for Gradle duplicate-property cleanup and PKCS12 truststore regeneration, and update the README.

## Why it changed
Gradle builds using `~/.gradle/custom-cacerts` were failing PKIX validation because that managed PKCS12 store did not contain the currently required THG/Netskope interception chain for GitHub-hosted package assets.

## User impact
Running `./fumitm.py --fix --provider netskope --tools gradle` now rebuilds `~/.gradle/custom-cacerts` with the active Java trust roots plus the required proxy chain, then points `gradle.properties` at that managed store.

## Root cause
fumitm only managed the Gradle property wiring and did not rebuild or validate the PKCS12 `custom-cacerts` store itself. It also treated multi-certificate PEM chains as a single alias import and left duplicate trustStore keys in place, which allowed a later vendor block to keep overriding the intended settings.

## Validation
- `.venv/bin/python -m pytest -q`
- `./fumitm.py --fix --provider netskope --tools gradle`
- `keytool -list -keystore ~/.gradle/custom-cacerts -storepass changeit -storetype PKCS12` now shows `netskope`, `netskope-zerotrust`, `netskope-zerotrust-2`, and `aikido-root`.
- `JAVA_HOME=/Users/Rishabh.Joshi01@thehutgroup.com/.sdkman/candidates/java/17.0.10-tem ./gradlew compileJava` in `procure-user-backend` progressed past dependency resolution and failed later on an unrelated source compilation error.
